### PR TITLE
fix failing tests - initialize sshkeys array in test object

### DIFF
--- a/pkg/apis/vsphereproviderconfig/v1alpha1/vsphereclusterproviderconfig_types_test.go
+++ b/pkg/apis/vsphereproviderconfig/v1alpha1/vsphereclusterproviderconfig_types_test.go
@@ -34,7 +34,9 @@ func TestStorageVsphereClusterProviderConfig(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "default",
-		}}
+		},
+		SSHKeys: make([]string, 0),
+	}
 	g := gomega.NewGomegaWithT(t)
 
 	// Test Create


### PR DESCRIPTION
Workaround to fix validation errors.

Perhaps a better solution is available, i.e. fix the validation instead of relying on this workaround.