### PR TITLE
NKS-1035 Multiple ssh keys for Debian

### DIFF
--- a/pkg/cloud/vsphere/provisioner/common/templates.go
+++ b/pkg/cloud/vsphere/provisioner/common/templates.go
@@ -306,7 +306,9 @@ const cloudInitDebianUserData = `
 users:
 - name: debian
   ssh_authorized_keys:
-    - {{ .SSHPublicKey }}
+  {{- range $sshKey := .SSHPublicKeys}}
+    - {{ $sshKey }}
+  {{- end }}
   sudo: ALL=(ALL) NOPASSWD:ALL
   groups: sudo
   shell: /bin/bash


### PR DESCRIPTION
Changing the user-data script to accept multiple SSH keys for the Debian scenario, just like we did with Ubuntu.