### PR TITLE
Use creds from secret in cloud config

### DIFF
--- a/pkg/cloud/vsphere/provisioner/govmomi/create.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/create.go
@@ -498,13 +498,18 @@ func (pv *Provisioner) getCloudProviderConfig(cluster *clusterv1.Cluster, machin
 		klog.Infof("Using input vSphere server url: %s", server)
 	}
 
+	username, password, err := pv.GetVsphereCredentials(cluster)
+	if err != nil {
+		return "", err
+	}
+
 	// TODO(ssurana): revisit once we solve https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/60
 	cpc := vpshereprovisionercommon.CloudProviderConfigTemplate{
 		Datacenter:   machineconfig.MachineSpec.Datacenter,
 		Server:       server,
 		Insecure:     true, // TODO(ssurana): Needs to be a user input
-		UserName:     clusterConfig.VsphereUser,
-		Password:     clusterConfig.VspherePassword,
+		UserName:     username,
+		Password:     password,
 		ResourcePool: machineconfig.MachineSpec.ResourcePool,
 		Datastore:    machineconfig.MachineSpec.Datastore,
 		Network:      "",


### PR DESCRIPTION
Bugfix.

cluster-api-provider-vsphere recently got the ability to read VSphere credentials from secret. Previously they were stored in plaintext on the cluster object (ClusterProviderSpec).

However, when populating the CloudProviderConfig that gets injected into cluster VMs, cluster-api-provider-vsphere would still only look for the credentials in the ClusterProviderSpec, disregarding the credential secret.

This fixes that, so that the credentials that get injected into CloudProviderConfig are taken from secret or the ClusterProviderSpec (if no credential secret present).