### PR TITLE
NKS-1548 cloud provider credentials in secret

### DIFF
--- a/pkg/cloud/vsphere/provisioner/common/templates.go
+++ b/pkg/cloud/vsphere/provisioner/common/templates.go
@@ -209,6 +209,8 @@ type CloudProviderConfigTemplate struct {
 	Datacenter   string
 	Server       string
 	Insecure     bool
+	UserName     string
+	Password     string
 	ResourcePool string
 	Datastore    string
 	Network      string

--- a/pkg/cloud/vsphere/provisioner/common/templates.go
+++ b/pkg/cloud/vsphere/provisioner/common/templates.go
@@ -38,6 +38,9 @@ type TemplateParams struct {
 	Machine           *clusterv1.Machine
 	DockerImages      []string
 	Preloaded         bool
+	Server            string
+	UserNameB64       string
+	PasswordB64       string
 }
 
 // Returns the startup script for the nodes.
@@ -341,6 +344,8 @@ const cloudProviderConfig = `
 [Global]
 datacenters = "{{ .Datacenter }}"
 insecure-flag = "{{ if .Insecure }}1{{ else }}0{{ end }}" #set to 1 if the vCenter uses a self-signed cert
+secret-name = "vccm"
+secret-namespace = "kube-system"
 
 [VirtualCenter "{{ .Server }}"]
         user = "{{ .UserName }}"
@@ -1352,6 +1357,20 @@ for tries in $(seq 1 60); do
 	kubectl --kubeconfig /etc/kubernetes/kubelet.conf annotate --overwrite node $(hostname) cluster.k8s.io/machine=${MACHINE} && break
 	sleep 1
 done
+
+# create credentials secret
+cat > /tmp/vccm.yaml << EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vccm
+  namespace: kube-system
+data:
+  {{ .Server }}.username: {{ .UserNameB64 }}
+  {{ .Server }}.password: {{ .PasswordB64 }}
+EOF
+
+kubectl apply --kubeconfig /etc/kubernetes/admin.conf -f /tmp/vccm.yaml
 
 {{- end }}{{/* end configure */}}
 `

--- a/pkg/cloud/vsphere/provisioner/common/templates.go
+++ b/pkg/cloud/vsphere/provisioner/common/templates.go
@@ -209,8 +209,6 @@ type CloudProviderConfigTemplate struct {
 	Datacenter   string
 	Server       string
 	Insecure     bool
-	UserName     string
-	Password     string
 	ResourcePool string
 	Datastore    string
 	Network      string
@@ -347,9 +345,7 @@ insecure-flag = "{{ if .Insecure }}1{{ else }}0{{ end }}" #set to 1 if the vCent
 secret-name = "vccm"
 secret-namespace = "kube-system"
 
-[VirtualCenter "{{ .Server }}"]
-        user = "{{ .UserName }}"
-        password = "{{ .Password }}"
+[VirtualCenter "{{ .Server }}"]                
 
 [Workspace]
         server = "{{ .Server }}"

--- a/pkg/cloud/vsphere/provisioner/govmomi/create.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/create.go
@@ -508,6 +508,8 @@ func (pv *Provisioner) getCloudProviderConfig(cluster *clusterv1.Cluster, machin
 		Datacenter:   machineconfig.MachineSpec.Datacenter,
 		Server:       server,
 		Insecure:     true, // TODO(ssurana): Needs to be a user input
+		UserName:     "",
+		Password:     "",
 		ResourcePool: machineconfig.MachineSpec.ResourcePool,
 		Datastore:    machineconfig.MachineSpec.Datastore,
 		Network:      "",

--- a/pkg/cloud/vsphere/provisioner/govmomi/create.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/create.go
@@ -503,18 +503,11 @@ func (pv *Provisioner) getCloudProviderConfig(cluster *clusterv1.Cluster, machin
 
 	server := getServerFromClusterConfig(clusterConfig)
 
-	username, password, err := pv.GetVsphereCredentials(cluster)
-	if err != nil {
-		return "", err
-	}
-
 	// TODO(ssurana): revisit once we solve https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/60
 	cpc := vpshereprovisionercommon.CloudProviderConfigTemplate{
 		Datacenter:   machineconfig.MachineSpec.Datacenter,
 		Server:       server,
 		Insecure:     true, // TODO(ssurana): Needs to be a user input
-		UserName:     username,
-		Password:     password,
 		ResourcePool: machineconfig.MachineSpec.ResourcePool,
 		Datastore:    machineconfig.MachineSpec.Datastore,
 		Network:      "",


### PR DESCRIPTION
https://jira.ngage.netapp.com/browse/NKS-1548

This PR makes it so that we stop communicating the vsphere creds to cloud-provider in plaintext via the cloud-config.yaml. 

Instead, a secret name and namespace is defined in the cloud-config.yaml, instructing cloud-provider to get its creds from there.

The secret is populated as the last step in the master startup script. There is a slight chicken and egg problem - the cloud-provider will not have access to the credentials on first startup, as the secret has not been created yet. The secret gets created eventually and the system functions as normal.

Getting rid of this chicken and egg problem is a larger undertaking - should ideally change cluster-api to start using the out-of-tree vsphere-cloud-provider upstream, starting the cloud-provider pods after the cluster has been created and the secret populated.

This implementation however works for our purposes and minimizes changes to our fork.