### PR TITLE
NKS-1784 Default storage class for all clusters

### DIFF
--- a/pkg/cloud/vsphere/provisioner/govmomi/create.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/create.go
@@ -566,6 +566,7 @@ func (pv *Provisioner) getStartupScript(cluster *clusterv1.Cluster, machine *clu
 				Server:            server,
 				UserNameB64:       base64.StdEncoding.EncodeToString([]byte(username)),
 				PasswordB64:       base64.StdEncoding.EncodeToString([]byte(password)),
+				Datastore:         machineconfig.MachineSpec.Datastore,
 			},
 		)
 		if err != nil {


### PR DESCRIPTION
With this change we can omit creating a SC in the registration for the service cluster. This also creates the default storage class called vsphere for all user clusters.