### PR TITLE
NKS-1746 remove nodes when machines removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ config/default/vsphere_tmp
 
 # tmp files
 *.tmp
+
+# IDEs
+.vscode/*
+.idea/*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,6 +80,27 @@ spec:
       }
     }
 
+    stage('publish: dev') {
+      when {
+        branch 'PR-*'
+      }
+      environment {
+        GIT_COMMIT_SHORT = sh(
+                script: "printf \$(git rev-parse --short ${GIT_COMMIT})",
+                returnStdout: true
+        ).trim()
+      }
+      steps {
+        container('builder-base') {
+          script {
+            docker.withRegistry("https://$DOCKER_REGISTRY", "gcr:$ORG") {
+              image.push("netapp-dev-$GIT_COMMIT_SHORT")
+            }
+          }
+        }
+      }
+    }
+
     stage('publish: netapp') {
       when {
         branch 'netapp'

--- a/pkg/cloud/vsphere/provisioner/govmomi/delete.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/delete.go
@@ -9,6 +9,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
 	vsphereutils "sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/utils"
@@ -20,7 +21,27 @@ func (pv *Provisioner) Delete(ctx context.Context, cluster *clusterv1.Cluster, m
 	if cluster == nil {
 		return errors.New(constants.ClusterIsNullErr)
 	}
+	if exists, _ := pv.Exists(ctx, cluster, machine); exists {
+		err := pv.powerOffAndDestroy(ctx, cluster, machine)
+		if err != nil {
+			return err
+		}
+	}
 
+	// Delete the node object bound to the Machine via the Status.NodeRef reference
+	if machine.Status.NodeRef != nil {
+		// Do a force delete (grace period set to 0) as the underlying VM is already deleted
+		err := pv.k8sClient.Core().Nodes().Delete(machine.Status.NodeRef.Name, metav1.NewDeleteOptions(0))
+		if err != nil {
+			// Log the warning for unable to delete and that the user can delete the node manually. This error
+			// should not hold the Machine delete operation since the underlying VM is already deleted at this point
+			klog.Warningf("Could not remove the node %s bound to the machine automatically. Please manually remove the node if it is not already removed. Error encountered: %s", machine.Status.NodeRef.Name, err.Error())
+		}
+	}
+	return nil
+}
+
+func (pv *Provisioner) powerOffAndDestroy(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
 	s, err := pv.sessionFromProviderConfig(cluster, machine)
 	if err != nil {
 		return err
@@ -28,44 +49,41 @@ func (pv *Provisioner) Delete(ctx context.Context, cluster *clusterv1.Cluster, m
 	deletectx, cancel := context.WithCancel(*s.context)
 	defer cancel()
 
-	if exists, _ := pv.Exists(ctx, cluster, machine); exists {
-		moref, err := vsphereutils.GetMachineRef(machine)
-		if err != nil {
-			return err
-		}
-		var vm mo.VirtualMachine
-		vmref := types.ManagedObjectReference{
-			Type:  "VirtualMachine",
-			Value: moref,
-		}
-		err = s.session.RetrieveOne(deletectx, vmref, []string{"name", "runtime.powerState"}, &vm)
-		if err != nil {
-			return err
-		}
-		pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Killing", "Killing machine %v", machine.Name)
-		vmo := object.NewVirtualMachine(s.session.Client, vmref)
-		if vm.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
-			task, err := vmo.PowerOff(deletectx)
-			if err != nil {
-				klog.Infof("Error trigerring power off operation on the Virtual Machine %s", vm.Name)
-				return err
-			}
-			err = task.Wait(deletectx)
-			if err != nil {
-				klog.Infof("Error powering off the Virtual Machine %s", vm.Name)
-				return err
-			}
-		}
-		task, err := vmo.Destroy(deletectx)
-		taskinfo, err := task.WaitForResult(deletectx, nil)
-		if taskinfo.State == types.TaskInfoStateSuccess {
-			klog.Infof("Virtual Machine %v deleted successfully", vm.Name)
-			pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Killed", "Machine %v deletion complete", machine.Name)
-			return nil
-		}
-		pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Killed", "Machine %v deletion complete", machine.Name)
-		klog.Errorf("VM Deletion failed on pv with following reason %v", taskinfo.Reason)
-		return errors.New("VM Deletion failed")
+	moref, err := vsphereutils.GetMachineRef(machine)
+	if err != nil {
+		return err
 	}
-	return nil
+	var vm mo.VirtualMachine
+	vmref := types.ManagedObjectReference{
+		Type:  "VirtualMachine",
+		Value: moref,
+	}
+	err = s.session.RetrieveOne(deletectx, vmref, []string{"name", "runtime.powerState"}, &vm)
+	if err != nil {
+		return err
+	}
+	pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Killing", "Killing machine %v", machine.Name)
+	vmo := object.NewVirtualMachine(s.session.Client, vmref)
+	if vm.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
+		task, err := vmo.PowerOff(deletectx)
+		if err != nil {
+			klog.Infof("Error trigerring power off operation on the Virtual Machine %s", vm.Name)
+			return err
+		}
+		err = task.Wait(deletectx)
+		if err != nil {
+			klog.Infof("Error powering off the Virtual Machine %s", vm.Name)
+			return err
+		}
+	}
+	task, err := vmo.Destroy(deletectx)
+	taskinfo, err := task.WaitForResult(deletectx, nil)
+	if taskinfo.State == types.TaskInfoStateSuccess {
+		klog.Infof("Virtual Machine %v deleted successfully", vm.Name)
+		pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Killed", "Machine %v deletion complete", machine.Name)
+		return nil
+	}
+	pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Killed", "Machine %v deletion complete", machine.Name)
+	klog.Errorf("VM Deletion failed on pv with following reason %v", taskinfo.Reason)
+	return errors.New("VM Deletion failed")
 }


### PR DESCRIPTION
When deleting machines, the nodes would stay put in a NotReady state forever. This PR cherry-picks commits from an upstream PR to fix this - deleting the k8s nodes following the deletion of the VMs. 

**WIP** since this does not handle user clusters, only the service cluster.