### PR TITLE
NKS-1782 tag machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ config/default/vsphere_tmp
 
 # tmp files
 *.tmp
+
+# IDEs
+.vscode/*
+.idea/*

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1297,6 +1297,7 @@
     "github.com/google/uuid",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
+    "github.com/pkg/errors",
     "github.com/spf13/pflag",
     "github.com/vmware/govmomi",
     "github.com/vmware/govmomi/find",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -572,7 +572,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1796e0465930bae6ba7ac885719496f184f6cd1fd5a7356542aeeeea24ba0403"
+  digest = "1:22a138cfa8b88c9a91eecb5ad05fc19ca0265208e9d98a58bfff259100937964"
   name = "github.com/vmware/govmomi"
   packages = [
     ".",
@@ -590,6 +590,9 @@
     "toolbox",
     "toolbox/hgfs",
     "toolbox/vix",
+    "vapi/internal",
+    "vapi/rest",
+    "vapi/tags",
     "vim25",
     "vim25/debug",
     "vim25/methods",
@@ -1302,6 +1305,9 @@
     "github.com/vmware/govmomi/simulator",
     "github.com/vmware/govmomi/toolbox",
     "github.com/vmware/govmomi/toolbox/vix",
+    "github.com/vmware/govmomi/vapi/rest",
+    "github.com/vmware/govmomi/vapi/tags",
+    "github.com/vmware/govmomi/vim25",
     "github.com/vmware/govmomi/vim25/mo",
     "github.com/vmware/govmomi/vim25/soap",
     "github.com/vmware/govmomi/vim25/types",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,27 @@ pipeline {
       }
     }
 
+    stage('publish: dev') {
+      when {
+        branch 'PR-*'
+      }
+      environment {
+        GIT_COMMIT_SHORT = sh(
+                script: "printf \$(git rev-parse --short ${GIT_COMMIT})",
+                returnStdout: true
+        ).trim()
+      }
+      steps {
+        container('builder-base') {
+          script {
+            docker.withRegistry("https://${DOCKER_REGISTRY}", "gcr:${ORG}") {
+              image.push("netapp-dev-${GIT_COMMIT_SHORT}")
+            }
+          }
+        }
+      }
+    }
+
     stage('publish: netapp') {
       when {
         branch 'netapp'

--- a/pkg/cloud/vsphere/provisioner/govmomi/create.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/create.go
@@ -385,27 +385,6 @@ func Properties(vm *object.VirtualMachine) (*mo.VirtualMachine, error) {
 	return &props, nil
 }
 
-func getNKSClusterInfo(cluster *clusterv1.Cluster) (string, string, bool) {
-
-	var workspaceID = ""
-	var clusterID = ""
-	var isServiceCluster bool
-
-	if val, ok := cluster.Labels[WorkspaceIdLabel]; ok {
-		workspaceID = val
-	}
-	if val, ok := cluster.Labels[ClusterIdLabel]; ok {
-		clusterID = val
-	}
-	if val, ok := cluster.Labels[ClusterRoleLabel]; ok {
-		if val == ServiceClusterRole {
-			isServiceCluster = true
-		}
-	}
-
-	return clusterID, workspaceID, isServiceCluster
-}
-
 func (vc *Provisioner) updateVMReference(machine *clusterv1.Machine, vmref string) (*clusterv1.Machine, error) {
 	providerSpec, err := vsphereutils.GetMachineProviderSpec(machine.Spec.ProviderSpec)
 	if err != nil {

--- a/pkg/cloud/vsphere/provisioner/govmomi/create.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/create.go
@@ -27,13 +27,6 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/util"
 )
 
-const (
-	ClusterIdLabel     = "hci.nks.netapp.com/cluster"
-	WorkspaceIdLabel   = "hci.nks.netapp.com/workspace"
-	ClusterRoleLabel   = "hci.nks.netapp.com/role"
-	ServiceClusterRole = "service-cluster"
-)
-
 func (pv *Provisioner) Create(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
 	if cluster == nil {
 		return errors.New(constants.ClusterIsNullErr)

--- a/pkg/cloud/vsphere/provisioner/govmomi/create.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/create.go
@@ -194,6 +194,11 @@ func (pv *Provisioner) cloneVirtualMachine(s *SessionContext, cluster *clusterv1
 		spec.Config.MemoryMB = machineConfig.MachineSpec.MemoryMB
 	}
 	spec.Config.Annotation = fmt.Sprintf("Virtual Machine is part of the cluster %s managed by cluster-api", cluster.Name)
+
+	//hci.nks.netapp.com/cluster -> 999
+	//hci.nks.netapp.com/workspace -> 999
+	// Add custom fields here?
+
 	spec.Location.DiskMoveType = string(types.VirtualMachineRelocateDiskMoveOptionsMoveAllDiskBackingsAndConsolidate)
 	var src *object.VirtualMachine
 	if vsphereutils.IsValidUUID(machineConfig.MachineSpec.VMTemplate) {

--- a/pkg/cloud/vsphere/provisioner/govmomi/create.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/create.go
@@ -194,12 +194,10 @@ func (pv *Provisioner) cloneVirtualMachine(s *SessionContext, cluster *clusterv1
 		spec.Config.MemoryMB = machineConfig.MachineSpec.MemoryMB
 	}
 
-	clusterID, workspaceID, isServiceCluster := getNKSClusterInfo(cluster)
-	if isServiceCluster {
-		spec.Config.Annotation = fmt.Sprintf("VM is part of NKS service cluster %s with cluster ID %s in workspace %s", cluster.Name, clusterID, workspaceID)
-	} else {
-		spec.Config.Annotation = fmt.Sprintf("VM is part of NKS user cluster %s with cluster ID %s in workspace %s", cluster.Name, clusterID, workspaceID)
-	}
+	// NetApp
+	// TODO: At this point we do not know if it is a service cluster - need better communication of that
+	clusterID, workspaceID, _ := getNKSClusterInfo(cluster)
+	spec.Config.Annotation = fmt.Sprintf("VM is part of NKS kubernetes cluster %s with cluster ID %s in workspace with ID %s", cluster.Name, clusterID, workspaceID)
 
 	spec.Location.DiskMoveType = string(types.VirtualMachineRelocateDiskMoveOptionsMoveAllDiskBackingsAndConsolidate)
 	var src *object.VirtualMachine

--- a/pkg/cloud/vsphere/provisioner/govmomi/provisioner.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/provisioner.go
@@ -8,19 +8,21 @@ import (
 )
 
 type Provisioner struct {
-	clusterV1alpha1 clusterv1alpha1.ClusterV1alpha1Interface
-	lister          v1alpha1.Interface
-	eventRecorder   record.EventRecorder
-	sessioncache    map[string]interface{}
-	k8sClient       kubernetes.Interface
+	clusterV1alpha1  clusterv1alpha1.ClusterV1alpha1Interface
+	lister           v1alpha1.Interface
+	eventRecorder    record.EventRecorder
+	sessioncache     map[string]interface{}
+	restsessioncache map[string]interface{} // NetApp
+	k8sClient        kubernetes.Interface
 }
 
 func New(clusterV1alpha1 clusterv1alpha1.ClusterV1alpha1Interface, k8sClient kubernetes.Interface, lister v1alpha1.Interface, eventRecorder record.EventRecorder) (*Provisioner, error) {
 	return &Provisioner{
-		clusterV1alpha1: clusterV1alpha1,
-		lister:          lister,
-		eventRecorder:   eventRecorder,
-		sessioncache:    make(map[string]interface{}),
-		k8sClient:       k8sClient,
+		clusterV1alpha1:  clusterV1alpha1,
+		lister:           lister,
+		eventRecorder:    eventRecorder,
+		sessioncache:     make(map[string]interface{}),
+		restsessioncache: make(map[string]interface{}),
+		k8sClient:        k8sClient,
 	}, nil
 }

--- a/pkg/cloud/vsphere/provisioner/govmomi/provisioner.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/provisioner.go
@@ -22,7 +22,7 @@ func New(clusterV1alpha1 clusterv1alpha1.ClusterV1alpha1Interface, k8sClient kub
 		lister:           lister,
 		eventRecorder:    eventRecorder,
 		sessioncache:     make(map[string]interface{}),
-		restsessioncache: make(map[string]interface{}),
+		restsessioncache: make(map[string]interface{}), // NetApp
 		k8sClient:        k8sClient,
 	}, nil
 }

--- a/pkg/cloud/vsphere/provisioner/govmomi/session.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/session.go
@@ -6,8 +6,10 @@ import (
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
+	"k8s.io/klog"
 	"net/url"
 	vsphereutils "sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/utils"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
@@ -17,6 +19,11 @@ type SessionContext struct {
 	session *govmomi.Client
 	context *context.Context
 	finder  *find.Finder
+}
+
+// NetApp
+type RestSessionContext struct {
+	restClient *rest.Client
 }
 
 func (pv *Provisioner) sessionFromProviderConfig(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (*SessionContext, error) {
@@ -62,6 +69,7 @@ func (pv *Provisioner) sessionFromProviderConfig(cluster *clusterv1.Cluster, mac
 // NetApp
 func (pv *Provisioner) restClientFromProviderConfig(cluster *clusterv1.Cluster) (*rest.Client, error) {
 
+	var rsc RestSessionContext
 	ctx := context.Background()
 
 	vsphereConfig, err := vsphereutils.GetClusterProviderSpec(cluster.Spec.ProviderSpec)
@@ -69,14 +77,24 @@ func (pv *Provisioner) restClientFromProviderConfig(cluster *clusterv1.Cluster) 
 		return nil, err
 	}
 
-	soapURL, err := soap.ParseURL(vsphereConfig.VsphereServer)
-	if soapURL == nil || err != nil {
-		return nil, fmt.Errorf("error parsing vSphere URL %s : [%s]", soapURL, err)
-	}
-
 	username, password, err := pv.GetVsphereCredentials(cluster)
 	if err != nil {
 		return nil, err
+	}
+
+	if cachedClientContext, ok := pv.restsessioncache[vsphereConfig.VsphereServer+username]; ok {
+		cachedClientContext, ok := cachedClientContext.(RestSessionContext)
+		if ok {
+			if ok := restClientActive(cachedClientContext.restClient); ok {
+				klog.V(4).Infof("using cached rest client for server %s and user %s", vsphereConfig.VsphereServer, username)
+				return cachedClientContext.restClient, nil
+			}
+		}
+	}
+
+	soapURL, err := soap.ParseURL(vsphereConfig.VsphereServer)
+	if soapURL == nil || err != nil {
+		return nil, fmt.Errorf("error parsing vSphere URL %s : [%s]", soapURL, err)
 	}
 
 	soapClient := soap.NewClient(soapURL, true)
@@ -85,10 +103,30 @@ func (pv *Provisioner) restClientFromProviderConfig(cluster *clusterv1.Cluster) 
 		return nil, err
 	}
 
+	klog.V(4).Infof("creating new rest client for server %s and user %s", vsphereConfig.VsphereServer, username)
 	restClient := rest.NewClient(vimClient)
 	if err := restClient.Login(ctx, url.UserPassword(username, password)); err != nil {
 		return nil, err
 	}
 
+	rsc.restClient = restClient
+
+	pv.restsessioncache[vsphereConfig.VsphereServer+username] = rsc
+
 	return restClient, nil
+}
+
+// NetApp
+func restClientActive(client *rest.Client) bool {
+
+	// NOTE: Rest client does not expose an IsActive check out of the box. Rolling our own rudimentary one.
+
+	tm := tags.NewManager(client)
+
+	_, err := tm.GetTags(context.TODO())
+	if err != nil {
+		return false
+	}
+
+	return true
 }

--- a/pkg/cloud/vsphere/provisioner/govmomi/update.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/update.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/vapi/tags"
 	"time"
 
@@ -53,7 +52,7 @@ func (pv *Provisioner) Update(ctx context.Context, cluster *clusterv1.Cluster, m
 	}
 
 	// NetApp
-	pv.updateVMTags(updatectx, s.session, vmmo, cluster)
+	pv.updateVMTags(updatectx, vmmo, cluster)
 
 	if vmmo.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOn {
 		klog.Warningf("Machine %s is not running, rather it is in %s state", vmmo.Name, vmmo.Runtime.PowerState)
@@ -105,7 +104,7 @@ func (pv *Provisioner) updateIP(cluster *clusterv1.Cluster, machine *clusterv1.M
 }
 
 // NetApp
-func (pv *Provisioner) updateVMTags(ctx context.Context, session *govmomi.Client, vmMoRef mo.VirtualMachine, cluster *clusterv1.Cluster) {
+func (pv *Provisioner) updateVMTags(ctx context.Context, vmMoRef mo.VirtualMachine, cluster *clusterv1.Cluster) {
 
 	// NOTE: Doing this in a best-effort manner. In case of failures, simply log and continue.
 
@@ -115,9 +114,9 @@ func (pv *Provisioner) updateVMTags(ctx context.Context, session *govmomi.Client
 	clusterID, workspaceID, isServiceCluster := getNKSClusterInfo(cluster)
 	clusterInfoTagName := fmt.Sprintf(clusterInfoTagNameTemplate, workspaceID, clusterID, cluster.Name)
 
-	restClient, err := pv.getRestClientForSession(session, cluster)
+	restClient, err := pv.restClientFromProviderConfig(cluster)
 	if err != nil {
-		klog.V(4).Infof("could not get rest client for session - err: %s", err.Error())
+		klog.V(4).Infof("could not get rest client from provider config - err: %s", err.Error())
 		return
 	}
 	tagManager := tags.NewManager(restClient)

--- a/pkg/cloud/vsphere/provisioner/govmomi/utils.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/utils.go
@@ -234,3 +234,25 @@ func (pv *Provisioner) GetVsphereCredentials(cluster *clusterv1.Cluster) (string
 	return vsphereConfig.VsphereUser, vsphereConfig.VspherePassword, nil
 
 }
+
+// NetApp
+func getNKSClusterInfo(cluster *clusterv1.Cluster) (string, string, bool) {
+
+	var workspaceID = ""
+	var clusterID = ""
+	var isServiceCluster bool
+
+	if val, ok := cluster.Labels[WorkspaceIdLabel]; ok {
+		workspaceID = val
+	}
+	if val, ok := cluster.Labels[ClusterIdLabel]; ok {
+		clusterID = val
+	}
+	if val, ok := cluster.Labels[ClusterRoleLabel]; ok {
+		if val == ServiceClusterRole {
+			isServiceCluster = true
+		}
+	}
+
+	return clusterID, workspaceID, isServiceCluster
+}

--- a/pkg/cloud/vsphere/provisioner/govmomi/utils.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/utils.go
@@ -238,6 +238,11 @@ func (pv *Provisioner) GetVsphereCredentials(cluster *clusterv1.Cluster) (string
 // NetApp
 func getNKSClusterInfo(cluster *clusterv1.Cluster) (string, string, bool) {
 
+	const ClusterIdLabel     = "hci.nks.netapp.com/cluster"
+	const WorkspaceIdLabel   = "hci.nks.netapp.com/workspace"
+	const ClusterRoleLabel   = "hci.nks.netapp.com/role"
+	const ServiceClusterRole = "service-cluster"
+
 	var workspaceID = ""
 	var clusterID = ""
 	var isServiceCluster bool

--- a/pkg/cloud/vsphere/utils/tags.go
+++ b/pkg/cloud/vsphere/utils/tags.go
@@ -146,7 +146,12 @@ func getOrCreateNKSTagCategory(ctx context.Context, tm *tags.Manager) (*tags.Cat
 // NetApp
 func deleteNKSTagIfNoSubjects(ctx context.Context, tm *tags.Manager, tag *tags.Tag) error {
 
-	if len(tag.UsedBy) == 0 {
+	attachedObjects, err := tm.ListAttachedObjects(ctx, tag.ID)
+	if err != nil {
+		return errors.Wrapf(err, "could not list attached objects for tag with name %s", tag.Name)
+	}
+
+	if len(attachedObjects) == 0 {
 
 		klog.V(4).Infof("deleting tag %s", tag.Name)
 		err := tm.DeleteTag(ctx, tag)
@@ -167,7 +172,7 @@ func deleteNKSTagIfNoSubjects(ctx context.Context, tm *tags.Manager, tag *tags.T
 		return nil
 	}
 
-	klog.V(4).Infof("will not delete tag with name %s - still used by %d objects", tag.Name, len(tag.UsedBy))
+	klog.V(4).Infof("will not delete tag with name %s - still used by %d objects", tag.Name, len(attachedObjects))
 	return nil
 }
 

--- a/pkg/cloud/vsphere/utils/tags.go
+++ b/pkg/cloud/vsphere/utils/tags.go
@@ -1,0 +1,116 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/vmware/govmomi/vapi/tags"
+	"github.com/vmware/govmomi/vim25/types"
+	"k8s.io/klog"
+)
+
+// NetApp
+const (
+	categoryName               = "NKS"
+	clusterInfoTagNameTemplate = "nks.workspaceid.%s.clusterid.%s.clustername.%s"
+	serviceClusterTagName      = "nks.service.cluster"
+)
+
+// NetApp
+func TagWithClusterInfo(ctx context.Context, tm *tags.Manager, moref types.ManagedObjectReference, workspaceID string, clusterID string, clusterName string) error {
+
+	tagName := fmt.Sprintf(clusterInfoTagNameTemplate, workspaceID, clusterID, clusterName)
+
+	tag, err := getOrCreateNKSTag(ctx, tm, tagName)
+	if err != nil {
+		return err
+	}
+
+	err = tm.AttachTag(ctx, tag.ID, moref)
+	if err != nil {
+		return errors.Wrapf(err, "could not attach tag %s to object", tag.Name)
+	}
+
+	return nil
+}
+
+// NetApp
+func TagAsServiceCluster(ctx context.Context, tm *tags.Manager, moref types.ManagedObjectReference) error {
+
+	tag, err := getOrCreateNKSTag(ctx, tm, serviceClusterTagName)
+	if err != nil {
+		return err
+	}
+
+	err = tm.AttachTag(ctx, tag.ID, moref)
+	if err != nil {
+		return errors.Wrapf(err, "could not attach tag %s to object", tag.Name)
+	}
+
+	return nil
+}
+
+// NetApp
+func getOrCreateNKSTag(ctx context.Context, tm *tags.Manager, tagName string) (*tags.Tag, error) {
+
+	tag, err := tm.GetTag(ctx, tagName)
+	if err == nil && tag != nil {
+		return tag, nil
+	}
+
+	nksCategory, err := getOrCreateNKSTagCategory(ctx, tm)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get NKS tag category")
+	}
+
+	newTag := &tags.Tag{
+		Name:        tagName,
+		Description: "NKS tag",
+		CategoryID:  nksCategory.ID,
+	}
+
+	klog.V(4).Infof("creating vSphere tag %s", newTag.Name)
+	_, err = tm.CreateTag(ctx, newTag)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not create tag %s", newTag)
+	}
+
+	tag, err = tm.GetTag(ctx, tagName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get tag with name %s", tagName)
+	}
+
+	return tag, nil
+}
+
+// NetApp
+func getOrCreateNKSTagCategory(ctx context.Context, tm *tags.Manager) (*tags.Category, error) {
+
+	category, err := tm.GetCategory(ctx, categoryName)
+	if err == nil && category != nil {
+		return category, nil
+	}
+
+	newCategory := &tags.Category{
+		Name:        categoryName,
+		Description: "NKS tag category",
+		Cardinality: "MULTIPLE",
+		AssociableTypes: []string{
+			"Folder",
+			"VirtualMachine",
+		},
+	}
+
+	klog.V(4).Infof("creating vSphere tag category %s", newCategory.Name)
+	_, err = tm.CreateCategory(ctx, newCategory)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not create tag category %s", newCategory)
+	}
+
+	category, err = tm.GetCategory(ctx, categoryName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get tag category with name %s", categoryName)
+	}
+
+	return category, nil
+}

--- a/vendor/github.com/vmware/govmomi/vapi/internal/internal.go
+++ b/vendor/github.com/vmware/govmomi/vapi/internal/internal.go
@@ -1,0 +1,146 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// VAPI REST Paths
+const (
+	Path                         = "/rest/com/vmware"
+	SessionPath                  = "/cis/session"
+	CategoryPath                 = "/cis/tagging/category"
+	TagPath                      = "/cis/tagging/tag"
+	AssociationPath              = "/cis/tagging/tag-association"
+	LibraryPath                  = "/content/library"
+	LibraryItemPath              = "/content/library/item"
+	LibraryItemFilePath          = "/content/library/item/file"
+	LibraryItemUpdateSession     = "/content/library/item/update-session"
+	LibraryItemUpdateSessionFile = "/content/library/item/updatesession/file"
+	LocalLibraryPath             = "/content/local-library"
+	VCenterOVFLibraryItem        = "/vcenter/ovf/library-item"
+	SessionCookieName            = "vmware-api-session-id"
+)
+
+// AssociatedObject is the same structure as types.ManagedObjectReference,
+// just with a different field name (ID instead of Value).
+// In the API we use mo.Reference, this type is only used for wire transfer.
+type AssociatedObject struct {
+	Type  string `json:"type"`
+	Value string `json:"id"`
+}
+
+// Reference implements mo.Reference
+func (o AssociatedObject) Reference() types.ManagedObjectReference {
+	return types.ManagedObjectReference(o)
+}
+
+// Association for tag-association requests.
+type Association struct {
+	ObjectID *AssociatedObject `json:"object_id,omitempty"`
+}
+
+// NewAssociation returns an Association, converting ref to an AssociatedObject.
+func NewAssociation(ref mo.Reference) Association {
+	obj := AssociatedObject(ref.Reference())
+	return Association{
+		ObjectID: &obj,
+	}
+}
+
+// CloneURL defines an interface for cloned urls
+type CloneURL interface {
+	URL() *url.URL
+}
+
+// Resource wraps url.URL with helpers
+type Resource struct {
+	u *url.URL
+}
+
+// URL creates a URL resource
+func URL(c CloneURL, path string) *Resource {
+	r := &Resource{u: c.URL()}
+	r.u.Path = Path + path
+	return r
+}
+
+func (r *Resource) String() string {
+	return r.u.String()
+}
+
+// WithID appends id to the URL.Path
+func (r *Resource) WithID(id string) *Resource {
+	r.u.Path += "/id:" + id
+	return r
+}
+
+// WithAction sets adds action to the URL.RawQuery
+func (r *Resource) WithAction(action string) *Resource {
+	r.u.RawQuery = url.Values{
+		"~action": []string{action},
+	}.Encode()
+	return r
+}
+
+// WithParameter sets adds a parameter to the URL.RawQuery
+func (r *Resource) WithParameter(name string, value string) *Resource {
+	parameter := url.Values{}
+	parameter.Set(name, value)
+	r.u.RawQuery = parameter.Encode()
+	return r
+}
+
+// Request returns a new http.Request for the given method.
+// An optional body can be provided for POST and PATCH methods.
+func (r *Resource) Request(method string, body ...interface{}) *http.Request {
+	rdr := io.MultiReader() // empty body by default
+	if len(body) != 0 {
+		rdr = encode(body[0])
+	}
+	req, err := http.NewRequest(method, r.u.String(), rdr)
+	if err != nil {
+		panic(err)
+	}
+	return req
+}
+
+type errorReader struct {
+	e error
+}
+
+func (e errorReader) Read([]byte) (int, error) {
+	return -1, e.e
+}
+
+// encode body as JSON, deferring any errors until io.Reader is used.
+func encode(body interface{}) io.Reader {
+	var b bytes.Buffer
+	err := json.NewEncoder(&b).Encode(body)
+	if err != nil {
+		return errorReader{err}
+	}
+	return &b
+}

--- a/vendor/github.com/vmware/govmomi/vapi/rest/client.go
+++ b/vendor/github.com/vmware/govmomi/vapi/rest/client.go
@@ -1,0 +1,125 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/vmware/govmomi/vapi/internal"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+// Client extends soap.Client to support JSON encoding, while inheriting security features, debug tracing and session persistence.
+type Client struct {
+	*soap.Client
+}
+
+// NewClient creates a new Client instance.
+func NewClient(c *vim25.Client) *Client {
+	sc := c.Client.NewServiceClient(internal.Path, "")
+
+	return &Client{sc}
+}
+
+type Signer interface {
+	SignRequest(*http.Request) error
+}
+
+type signerContext struct{}
+
+func (c *Client) WithSigner(ctx context.Context, s Signer) context.Context {
+	return context.WithValue(ctx, signerContext{}, s)
+}
+
+// Do sends the http.Request, decoding resBody if provided.
+func (c *Client) Do(ctx context.Context, req *http.Request, resBody interface{}) error {
+	switch req.Method {
+	case http.MethodPost, http.MethodPatch:
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	if s, ok := ctx.Value(signerContext{}).(Signer); ok {
+		if err := s.SignRequest(req); err != nil {
+			return err
+		}
+	}
+
+	return c.Client.Do(ctx, req, func(res *http.Response) error {
+		switch res.StatusCode {
+		case http.StatusOK:
+		case http.StatusBadRequest:
+			// TODO: structured error types
+			detail, err := ioutil.ReadAll(res.Body)
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("%s: %s", res.Status, bytes.TrimSpace(detail))
+		default:
+			return fmt.Errorf("%s %s: %s", req.Method, req.URL, res.Status)
+		}
+
+		if resBody == nil {
+			return nil
+		}
+
+		switch b := resBody.(type) {
+		case io.Writer:
+			_, err := io.Copy(b, res.Body)
+			return err
+		default:
+			val := struct {
+				Value interface{} `json:"value,omitempty"`
+			}{
+				resBody,
+			}
+			return json.NewDecoder(res.Body).Decode(&val)
+		}
+	})
+}
+
+// Login creates a new session via Basic Authentication with the given url.Userinfo.
+func (c *Client) Login(ctx context.Context, user *url.Userinfo) error {
+	req := internal.URL(c, internal.SessionPath).Request(http.MethodPost)
+
+	if user != nil {
+		if password, ok := user.Password(); ok {
+			req.SetBasicAuth(user.Username(), password)
+		}
+	}
+
+	return c.Do(ctx, req, nil)
+}
+
+func (c *Client) LoginByToken(ctx context.Context) error {
+	return c.Login(ctx, nil)
+}
+
+// Logout deletes the current session.
+func (c *Client) Logout(ctx context.Context) error {
+	req := internal.URL(c, internal.SessionPath).Request(http.MethodDelete)
+	return c.Do(ctx, req, nil)
+}

--- a/vendor/github.com/vmware/govmomi/vapi/tags/categories.go
+++ b/vendor/github.com/vmware/govmomi/vapi/tags/categories.go
@@ -1,0 +1,162 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tags
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/vmware/govmomi/vapi/internal"
+)
+
+// Category provides methods to create, read, update, delete, and enumerate categories.
+type Category struct {
+	ID              string   `json:"id,omitempty"`
+	Name            string   `json:"name,omitempty"`
+	Description     string   `json:"description,omitempty"`
+	Cardinality     string   `json:"cardinality,omitempty"`
+	AssociableTypes []string `json:"associable_types,omitempty"`
+	UsedBy          []string `json:"used_by,omitempty"`
+}
+
+func (c *Category) hasType(kind string) bool {
+	for _, k := range c.AssociableTypes {
+		if kind == k {
+			return true
+		}
+	}
+	return false
+}
+
+// Patch merges Category changes from the given src.
+// AssociableTypes can only be appended to and cannot shrink.
+func (c *Category) Patch(src *Category) {
+	if src.Name != "" {
+		c.Name = src.Name
+	}
+	if src.Description != "" {
+		c.Description = src.Description
+	}
+	if src.Cardinality != "" {
+		c.Cardinality = src.Cardinality
+	}
+	// Note that in order to append to AssociableTypes any existing types must be included in their original order.
+	for _, kind := range src.AssociableTypes {
+		if !c.hasType(kind) {
+			c.AssociableTypes = append(c.AssociableTypes, kind)
+		}
+	}
+}
+
+// CreateCategory creates a new category and returns the category ID.
+func (c *Manager) CreateCategory(ctx context.Context, category *Category) (string, error) {
+	// create avoids the annoyance of CreateTag requiring field keys to be included in the request,
+	// even though the field value can be empty.
+	type create struct {
+		Name            string   `json:"name"`
+		Description     string   `json:"description"`
+		Cardinality     string   `json:"cardinality"`
+		AssociableTypes []string `json:"associable_types"`
+	}
+	spec := struct {
+		Category create `json:"create_spec"`
+	}{
+		Category: create{
+			Name:            category.Name,
+			Description:     category.Description,
+			Cardinality:     category.Cardinality,
+			AssociableTypes: category.AssociableTypes,
+		},
+	}
+	if spec.Category.AssociableTypes == nil {
+		// otherwise create fails with invalid_argument
+		spec.Category.AssociableTypes = []string{}
+	}
+	url := internal.URL(c, internal.CategoryPath)
+	var res string
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// UpdateCategory can update one or more of the AssociableTypes, Cardinality, Description and Name fields.
+func (c *Manager) UpdateCategory(ctx context.Context, category *Category) error {
+	spec := struct {
+		Category Category `json:"update_spec"`
+	}{
+		Category: Category{
+			AssociableTypes: category.AssociableTypes,
+			Cardinality:     category.Cardinality,
+			Description:     category.Description,
+			Name:            category.Name,
+		},
+	}
+	url := internal.URL(c, internal.CategoryPath).WithID(category.ID)
+	return c.Do(ctx, url.Request(http.MethodPatch, spec), nil)
+}
+
+// DeleteCategory deletes an existing category.
+func (c *Manager) DeleteCategory(ctx context.Context, category *Category) error {
+	url := internal.URL(c, internal.CategoryPath).WithID(category.ID)
+	return c.Do(ctx, url.Request(http.MethodDelete), nil)
+}
+
+// GetCategory fetches the category information for the given identifier.
+// The id parameter can be a Category ID or Category Name.
+func (c *Manager) GetCategory(ctx context.Context, id string) (*Category, error) {
+	if isName(id) {
+		cat, err := c.GetCategories(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range cat {
+			if cat[i].Name == id {
+				return &cat[i], nil
+			}
+		}
+	}
+	url := internal.URL(c, internal.CategoryPath).WithID(id)
+	var res Category
+	return &res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// ListCategories returns all category IDs in the system.
+func (c *Manager) ListCategories(ctx context.Context) ([]string, error) {
+	url := internal.URL(c, internal.CategoryPath)
+	var res []string
+	return res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// GetCategories fetches an array of category information in the system.
+func (c *Manager) GetCategories(ctx context.Context) ([]Category, error) {
+	ids, err := c.ListCategories(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list categories: %s", err)
+	}
+
+	var categories []Category
+	for _, id := range ids {
+		category, err := c.GetCategory(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("get category %s: %s", id, err)
+		}
+
+		categories = append(categories, *category)
+
+	}
+	return categories, nil
+}

--- a/vendor/github.com/vmware/govmomi/vapi/tags/tag_association.go
+++ b/vendor/github.com/vmware/govmomi/vapi/tags/tag_association.go
@@ -1,0 +1,105 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+vUnless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tags
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/vmware/govmomi/vapi/internal"
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+func (c *Manager) tagID(ctx context.Context, id string) (string, error) {
+	if isName(id) {
+		tag, err := c.GetTag(ctx, id)
+		if err != nil {
+			return "", err
+		}
+		return tag.ID, nil
+	}
+	return id, nil
+}
+
+// AttachTag attaches a tag ID to a managed object.
+func (c *Manager) AttachTag(ctx context.Context, tagID string, ref mo.Reference) error {
+	id, err := c.tagID(ctx, tagID)
+	if err != nil {
+		return err
+	}
+	spec := internal.NewAssociation(ref)
+	url := internal.URL(c, internal.AssociationPath).WithID(id).WithAction("attach")
+	return c.Do(ctx, url.Request(http.MethodPost, spec), nil)
+}
+
+// DetachTag detaches a tag ID from a managed object.
+// If the tag is already removed from the object, then this operation is a no-op and an error will not be thrown.
+func (c *Manager) DetachTag(ctx context.Context, tagID string, ref mo.Reference) error {
+	id, err := c.tagID(ctx, tagID)
+	if err != nil {
+		return err
+	}
+	spec := internal.NewAssociation(ref)
+	url := internal.URL(c, internal.AssociationPath).WithID(id).WithAction("detach")
+	return c.Do(ctx, url.Request(http.MethodPost, spec), nil)
+}
+
+// ListAttachedTags fetches the array of tag IDs attached to the given object.
+func (c *Manager) ListAttachedTags(ctx context.Context, ref mo.Reference) ([]string, error) {
+	spec := internal.NewAssociation(ref)
+	url := internal.URL(c, internal.AssociationPath).WithAction("list-attached-tags")
+	var res []string
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// GetAttachedTags fetches the array of tags attached to the given object.
+func (c *Manager) GetAttachedTags(ctx context.Context, ref mo.Reference) ([]Tag, error) {
+	ids, err := c.ListAttachedTags(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("get attached tags %s: %s", ref, err)
+	}
+
+	var info []Tag
+	for _, id := range ids {
+		tag, err := c.GetTag(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("get tag %s: %s", id, err)
+		}
+		info = append(info, *tag)
+	}
+	return info, nil
+}
+
+// ListAttachedObjects fetches the array of attached objects for the given tag ID.
+func (c *Manager) ListAttachedObjects(ctx context.Context, tagID string) ([]mo.Reference, error) {
+	id, err := c.tagID(ctx, tagID)
+	if err != nil {
+		return nil, err
+	}
+	url := internal.URL(c, internal.AssociationPath).WithID(id).WithAction("list-attached-objects")
+	var res []internal.AssociatedObject
+	if err := c.Do(ctx, url.Request(http.MethodPost, nil), &res); err != nil {
+		return nil, err
+	}
+
+	refs := make([]mo.Reference, len(res))
+	for i := range res {
+		refs[i] = res[i]
+	}
+	return refs, nil
+}

--- a/vendor/github.com/vmware/govmomi/vapi/tags/tags.go
+++ b/vendor/github.com/vmware/govmomi/vapi/tags/tags.go
@@ -1,0 +1,226 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tags
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/vmware/govmomi/vapi/internal"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+// Manager extends rest.Client, adding tag related methods.
+type Manager struct {
+	*rest.Client
+}
+
+// NewManager creates a new Manager instance with the given client.
+func NewManager(client *rest.Client) *Manager {
+	return &Manager{
+		Client: client,
+	}
+}
+
+// isName returns true if the id is not a urn.
+func isName(id string) bool {
+	return !strings.HasPrefix(id, "urn:")
+}
+
+// Tag provides methods to create, read, update, delete, and enumerate tags.
+type Tag struct {
+	ID          string   `json:"id,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	CategoryID  string   `json:"category_id,omitempty"`
+	UsedBy      []string `json:"used_by,omitempty"`
+}
+
+// Patch merges updates from the given src.
+func (t *Tag) Patch(src *Tag) {
+	if src.Name != "" {
+		t.Name = src.Name
+	}
+	if src.Description != "" {
+		t.Description = src.Description
+	}
+	if src.CategoryID != "" {
+		t.CategoryID = src.CategoryID
+	}
+}
+
+// CreateTag creates a new tag with the given Name, Description and CategoryID.
+func (c *Manager) CreateTag(ctx context.Context, tag *Tag) (string, error) {
+	// create avoids the annoyance of CreateTag requiring a "description" key to be included in the request,
+	// even though the field value can be empty.
+	type create struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		CategoryID  string `json:"category_id"`
+	}
+	spec := struct {
+		Tag create `json:"create_spec"`
+	}{
+		Tag: create{
+			Name:        tag.Name,
+			Description: tag.Description,
+			CategoryID:  tag.CategoryID,
+		},
+	}
+	if isName(tag.CategoryID) {
+		cat, err := c.GetCategory(ctx, tag.CategoryID)
+		if err != nil {
+			return "", err
+		}
+		spec.Tag.CategoryID = cat.ID
+	}
+	url := internal.URL(c, internal.TagPath)
+	var res string
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// UpdateTag can update one or both of the tag Description and Name fields.
+func (c *Manager) UpdateTag(ctx context.Context, tag *Tag) error {
+	spec := struct {
+		Tag Tag `json:"update_spec"`
+	}{
+		Tag: Tag{
+			Name:        tag.Name,
+			Description: tag.Description,
+		},
+	}
+	url := internal.URL(c, internal.TagPath).WithID(tag.ID)
+	return c.Do(ctx, url.Request(http.MethodPatch, spec), nil)
+}
+
+// DeleteTag deletes an existing tag.
+func (c *Manager) DeleteTag(ctx context.Context, tag *Tag) error {
+	url := internal.URL(c, internal.TagPath).WithID(tag.ID)
+	return c.Do(ctx, url.Request(http.MethodDelete), nil)
+}
+
+// GetTag fetches the tag information for the given identifier.
+// The id parameter can be a Tag ID or Tag Name.
+func (c *Manager) GetTag(ctx context.Context, id string) (*Tag, error) {
+	if isName(id) {
+		tags, err := c.GetTags(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range tags {
+			if tags[i].Name == id {
+				return &tags[i], nil
+			}
+		}
+	}
+
+	url := internal.URL(c, internal.TagPath).WithID(id)
+	var res Tag
+	return &res, c.Do(ctx, url.Request(http.MethodGet), &res)
+
+}
+
+// GetTagForCategory fetches the tag information for the given identifier in the given category.
+func (c *Manager) GetTagForCategory(ctx context.Context, id, category string) (*Tag, error) {
+	if category == "" {
+		return c.GetTag(ctx, id)
+	}
+
+	ids, err := c.ListTagsForCategory(ctx, category)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, id := range ids {
+		tag, err := c.GetTag(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("get tag for category %s %s: %s", category, id, err)
+		}
+		if tag.ID == id || tag.Name == id {
+			return tag, nil
+		}
+	}
+
+	return nil, fmt.Errorf("tag %q not found in category %q", id, category)
+}
+
+// ListTags returns all tag IDs in the system.
+func (c *Manager) ListTags(ctx context.Context) ([]string, error) {
+	url := internal.URL(c, internal.TagPath)
+	var res []string
+	return res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// GetTags fetches an array of tag information in the system.
+func (c *Manager) GetTags(ctx context.Context) ([]Tag, error) {
+	ids, err := c.ListTags(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get tags failed for: %s", err)
+	}
+
+	var tags []Tag
+	for _, id := range ids {
+		tag, err := c.GetTag(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("get category %s failed for %s", id, err)
+		}
+
+		tags = append(tags, *tag)
+
+	}
+	return tags, nil
+}
+
+// The id parameter can be a Category ID or Category Name.
+func (c *Manager) ListTagsForCategory(ctx context.Context, id string) ([]string, error) {
+	if isName(id) {
+		cat, err := c.GetCategory(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		id = cat.ID
+	}
+
+	body := struct {
+		ID string `json:"category_id"`
+	}{id}
+	url := internal.URL(c, internal.TagPath).WithID(id).WithAction("list-tags-for-category")
+	var res []string
+	return res, c.Do(ctx, url.Request(http.MethodPost, body), &res)
+}
+
+// The id parameter can be a Category ID or Category Name.
+func (c *Manager) GetTagsForCategory(ctx context.Context, id string) ([]Tag, error) {
+	ids, err := c.ListTagsForCategory(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	var tags []Tag
+	for _, id := range ids {
+		tag, err := c.GetTag(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("get tag %s: %s", id, err)
+		}
+
+		tags = append(tags, *tag)
+	}
+	return tags, nil
+}


### PR DESCRIPTION
This PR tags VMs in vSphere with cluster information (cluster ID, workspace ID and cluster name).
It also tags service cluster machines as such. An "NKS" tag category is also created for the tags.

The annotation on the VMs is also updated to be more descriptive.

The tagging is done in the `Update()`operation of the govmomi provisioner, triggered in the machine reconciliation. Note that the tagging is best-effort, just logging errors on failure.

The tags are deleted in the `Delete()` operation of the provisioner. A tag is deleted if it contains no more subjects (i.e. no objects are tagged with that tag). The tag category is also deleted if it contains no more tags. The delete operation is also best-effort.