### PR TITLE
NKS-1840 netapp addons

### DIFF
--- a/pkg/cloud/vsphere/services/govmomi/create.go
+++ b/pkg/cloud/vsphere/services/govmomi/create.go
@@ -70,7 +70,7 @@ func Create(ctx *context.MachineContext, bootstrapToken string) error {
 		return errors.Wrapf(err, "error generating user data for %q", ctx)
 	}
 
-	if ctx.Session.IsVC() {
+	if ctx.Session.IsVC() { // Debug here
 		return vcenter.Clone(ctx, userData)
 	}
 	return esxi.Clone(ctx, userData)
@@ -227,6 +227,11 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 				return nil, err
 			}
 
+			netappBootScript, err := userdata.NewNetAppBootScript()
+			if err != nil {
+				return nil, err
+			}
+
 			userData, err := userdata.NewControlPlane(&userdata.ControlPlaneInput{
 				SSHAuthorizedKeys:    ctx.ClusterConfig.SSHAuthorizedKeys,
 				CACert:               string(ctx.ClusterConfig.CAKeyPair.Cert),
@@ -240,6 +245,7 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 				CloudConfig:          cloudConfig,
 				ClusterConfiguration: clusterConfigYAML,
 				InitConfiguration:    initConfigYAML,
+				NetAppBootScript:     netappBootScript,
 			})
 			if err != nil {
 				return nil, err

--- a/pkg/cloud/vsphere/services/govmomi/create.go
+++ b/pkg/cloud/vsphere/services/govmomi/create.go
@@ -70,7 +70,7 @@ func Create(ctx *context.MachineContext, bootstrapToken string) error {
 		return errors.Wrapf(err, "error generating user data for %q", ctx)
 	}
 
-	if ctx.Session.IsVC() { // Debug here
+	if ctx.Session.IsVC() {
 		return vcenter.Clone(ctx, userData)
 	}
 	return esxi.Clone(ctx, userData)
@@ -227,7 +227,10 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 				return nil, err
 			}
 
-			netappBootScript, err := userdata.NewNetAppBootScript()
+			// NetApp
+			netappBootScript, err := userdata.NewNetAppBootScript(&userdata.NetAppBootScriptInput{
+				Datastore: ctx.MachineConfig.Datastore,
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -245,7 +248,7 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 				CloudConfig:          cloudConfig,
 				ClusterConfiguration: clusterConfigYAML,
 				InitConfiguration:    initConfigYAML,
-				NetAppBootScript:     netappBootScript,
+				NetAppBootScript:     netappBootScript, // NetApp
 			})
 			if err != nil {
 				return nil, err

--- a/pkg/cloud/vsphere/services/govmomi/create.go
+++ b/pkg/cloud/vsphere/services/govmomi/create.go
@@ -228,7 +228,7 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 			}
 
 			// NetApp
-			netappBootScript, err := userdata.NewNetAppBootScript(&userdata.NetAppBootScriptInput{
+			bootScript, err := userdata.NewBootScript(&userdata.BootScriptInput{
 				Datastore: ctx.MachineConfig.Datastore,
 			})
 			if err != nil {
@@ -248,7 +248,7 @@ func generateUserData(ctx *context.MachineContext, bootstrapToken string) ([]byt
 				CloudConfig:          cloudConfig,
 				ClusterConfiguration: clusterConfigYAML,
 				InitConfiguration:    initConfigYAML,
-				NetAppBootScript:     netappBootScript, // NetApp
+				BootScript:           bootScript, // NetApp
 			})
 			if err != nil {
 				return nil, err

--- a/pkg/cloud/vsphere/services/userdata/controlplane.go
+++ b/pkg/cloud/vsphere/services/userdata/controlplane.go
@@ -114,6 +114,13 @@ write_files:
     content: |
       {{.CloudConfig | Base64Encode}}
 
+-   path: /tmp/netapp-boot.sh
+    encoding: "base64"
+    owner: root:root
+    permissions: '0755'
+    content: |
+      {{.NetAppBootScript | Base64Encode}}
+
 -   path: /tmp/kubeadm.yaml
     owner: root:root
     permissions: '0640'
@@ -122,9 +129,12 @@ write_files:
 {{.ClusterConfiguration | Indent 6}}
       ---
 {{.InitConfiguration | Indent 6}}
-kubeadm:
-  operation: init
-  config: /tmp/kubeadm.yaml
+#kubeadm:
+#  operation: init
+#  config: /tmp/kubeadm.yaml
+
+runcmd:
+  - /tmp/netapp-boot.sh
 
 `
 
@@ -228,6 +238,7 @@ type ControlPlaneInput struct {
 	CloudConfig          string
 	ClusterConfiguration string
 	InitConfiguration    string
+	NetAppBootScript     string
 }
 
 // ContolPlaneJoinInput defines context to generate controlplane instance user data for controlplane node join.

--- a/pkg/cloud/vsphere/services/userdata/controlplane.go
+++ b/pkg/cloud/vsphere/services/userdata/controlplane.go
@@ -238,7 +238,7 @@ type ControlPlaneInput struct {
 	CloudConfig          string
 	ClusterConfiguration string
 	InitConfiguration    string
-	NetAppBootScript     string
+	BootScript           string // NetApp
 }
 
 // ContolPlaneJoinInput defines context to generate controlplane instance user data for controlplane node join.

--- a/pkg/cloud/vsphere/services/userdata/controlplane.go
+++ b/pkg/cloud/vsphere/services/userdata/controlplane.go
@@ -119,7 +119,7 @@ write_files:
     owner: root:root
     permissions: '0755'
     content: |
-      {{.NetAppBootScript | Base64Encode}}
+      {{.BootScript | Base64Encode}}
 
 -   path: /tmp/kubeadm.yaml
     owner: root:root
@@ -129,6 +129,8 @@ write_files:
 {{.ClusterConfiguration | Indent 6}}
       ---
 {{.InitConfiguration | Indent 6}}
+
+# NetApp - using customized boot script via runcmd in favour of kubadm cloud init operation
 #kubeadm:
 #  operation: init
 #  config: /tmp/kubeadm.yaml

--- a/pkg/cloud/vsphere/services/userdata/netapp-addons.go
+++ b/pkg/cloud/vsphere/services/userdata/netapp-addons.go
@@ -13,30 +13,28 @@ func NewBootScript(input *BootScriptInput) (string, error) {
 		return "", err
 	}
 
-	type ScriptValues struct {
+	type scriptValues struct {
 		CalicoYAML              string
 		DefaultStorageClassYAML string
 	}
 
-	values := ScriptValues{
+	values := scriptValues{
 		CalicoYAML:              calicoYAML,
 		DefaultStorageClassYAML: defaultStorageClassYAML,
 	}
 
-	return generate("BootScript", netappBootScript, values)
+	return generate("BootScript", bootScript, values)
 }
 
 const (
-	netappBootScript = `#!/bin/bash
+	bootScript = `#!/bin/bash
 
-set -o errexit
+set -e
+set -x
 
-readonly LOG_FILE="addons-log.txt"
-
+readonly LOG_FILE="bootscript-log.txt"
 touch $LOG_FILE
-
 exec 1>>$LOG_FILE
-
 exec 2>>$LOG_FILE
 
 kubeadm init --config /tmp/kubeadm.yaml
@@ -54,9 +52,6 @@ cat > netapp-addons/default-storage-class.yaml << EOF
 {{.DefaultStorageClassYAML}}
 EOF
 kubectl apply --kubeconfig=/etc/kubernetes/admin.conf -f netapp-addons/default-storage-class.yaml
-
-# Trident
-
 `
 
 	storageClassYAMLTemplate = `kind: StorageClass

--- a/pkg/cloud/vsphere/services/userdata/netapp-addons.go
+++ b/pkg/cloud/vsphere/services/userdata/netapp-addons.go
@@ -1,0 +1,812 @@
+package userdata
+
+const (
+	netappBootScript = `#!/bin/bash
+
+set -o errexit
+
+readonly LOG_FILE="addons-log.txt"
+
+touch $LOG_FILE
+
+exec 1>>$LOG_FILE
+
+exec 2>>$LOG_FILE
+
+kubeadm init --config /tmp/kubeadm.yaml
+
+mkdir netapp-addons
+
+# Calico
+cat > netapp-addons/calico.yaml << EOF
+{{.CalicoYAML}}
+EOF
+kubectl apply --kubeconfig=/etc/kubernetes/admin.conf -f netapp-addons/calico.yaml
+
+# Default storage class
+cat > netapp-addons/default-storage-class.yaml << EOF
+{{.DefaultStorageClass.yaml}}
+EOF
+kubectl apply --kubeconfig=/etc/kubernetes/admin.conf -f netapp-addons/default-storage-class.yaml
+
+# Trident
+
+`
+
+	storageClassYAMLTemplate = `kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: vsphere
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/vsphere-volume
+parameters:
+  datastore: {{.Datastore}}
+  diskformat: thin
+  fstype: ext3
+`
+
+	calicoYAML = `# Calico Version v3.6
+# https://docs.projectcalico.org/v3.6/release-notes/
+---
+# Source: calico/templates/calico-config.yaml
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  # Typha is disabled.
+  typha_service_name: "none"
+  # Configure the Calico backend to use.
+  calico_backend: "bird"
+
+  # Configure the MTU to use
+  veth_mtu: "1440"
+
+  # The CNI network configuration to install on each node.  The special
+  # values in this config will be automatically populated.
+  cni_network_config: |-
+    {
+      "name": "k8s-pod-network",
+      "cniVersion": "0.3.0",
+      "plugins": [
+        {
+          "type": "calico",
+          "log_level": "info",
+          "datastore_type": "kubernetes",
+          "nodename": "__KUBERNETES_NODE_NAME__",
+          "mtu": __CNI_MTU__,
+          "ipam": {
+              "type": "calico-ipam"
+          },
+          "policy": {
+              "type": "k8s"
+          },
+          "kubernetes": {
+              "kubeconfig": "__KUBECONFIG_FILEPATH__"
+          }
+        },
+        {
+          "type": "portmap",
+          "snat": true,
+          "capabilities": {"portMappings": true}
+        }
+      ]
+    }
+---
+# Source: calico/templates/kdd-crds.yaml
+# Create all the CustomResourceDefinitions needed for
+# Calico policy and networking mode.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+   name: felixconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: FelixConfiguration
+    plural: felixconfigurations
+    singular: felixconfiguration
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamblocks.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPAMBlock
+    plural: ipamblocks
+    singular: ipamblock
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: blockaffinities.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BlockAffinity
+    plural: blockaffinities
+    singular: blockaffinity
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamhandles.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPAMHandle
+    plural: ipamhandles
+    singular: ipamhandle
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamconfigs.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPAMConfig
+    plural: ipamconfigs
+    singular: ipamconfig
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bgppeers.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BGPPeer
+    plural: bgppeers
+    singular: bgppeer
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: BGPConfiguration
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ippools.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: IPPool
+    plural: ippools
+    singular: ippool
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: HostEndpoint
+    plural: hostendpoints
+    singular: hostendpoint
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: ClusterInformation
+    plural: clusterinformations
+    singular: clusterinformation
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalNetworkPolicy
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: GlobalNetworkSet
+    plural: globalnetworksets
+    singular: globalnetworkset
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: NetworkPolicy
+    plural: networkpolicies
+    singular: networkpolicy
+---
+# Source: calico/templates/rbac.yaml
+
+# Include a clusterrole for the kube-controllers component,
+# and bind it to the calico-kube-controllers serviceaccount.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-kube-controllers
+rules:
+  # Nodes are watched to monitor for deletions.
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - watch
+      - list
+      - get
+  # Pods are queried to check for existence.
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+  # IPAM resources are manipulated when nodes are deleted.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ippools
+    verbs:
+      - list
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+  # Needs access to update clusterinformations.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - clusterinformations
+    verbs:
+      - get
+      - create
+      - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-kube-controllers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-kube-controllers
+subjects:
+- kind: ServiceAccount
+  name: calico-kube-controllers
+  namespace: kube-system
+---
+# Include a clusterrole for the calico-node DaemonSet,
+# and bind it to the calico-node serviceaccount.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-node
+rules:
+  # The CNI plugin needs to get pods, nodes, and namespaces.
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - endpoints
+      - services
+    verbs:
+      # Used to discover service IPs for advertisement.
+      - watch
+      - list
+      # Used to discover Typhas.
+      - get
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+      # Calico stores some configuration information in node annotations.
+      - update
+  # Watch for changes to Kubernetes NetworkPolicies.
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+  # Used by Calico for policy information.
+  - apiGroups: [""]
+    resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+    verbs:
+      - list
+      - watch
+  # The CNI plugin patches pods/status.
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - patch
+  # Calico monitors various CRDs for config.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - ipamblocks
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - clusterinformations
+      - hostendpoints
+    verbs:
+      - get
+      - list
+      - watch
+  # Calico must create and update some CRDs on startup.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+    verbs:
+      - create
+      - update
+  # Calico stores some configuration information on the node.
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  # These permissions are only requried for upgrade from v2.6, and can
+  # be removed after upgrade or on fresh installations.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - bgpconfigurations
+      - bgppeers
+    verbs:
+      - create
+      - update
+  # These permissions are required for Calico CNI to perform IPAM allocations.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ipamconfigs
+    verbs:
+      - get
+  # Block affinities must also be watchable by confd for route aggregation.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+    verbs:
+      - watch
+  # The Calico IPAM migration needs to get daemonsets. These permissions can be
+  # removed if not upgrading from an installation using host-local IPAM.
+  - apiGroups: ["apps"]
+    resources:
+      - daemonsets
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-node
+subjects:
+- kind: ServiceAccount
+  name: calico-node
+  namespace: kube-system
+---
+
+---
+# Source: calico/templates/calico-node.yaml
+# This manifest installs the node container, as well
+# as the Calico CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        # This, along with the CriticalAddonsOnly toleration below,
+        # marks the pod as a critical add-on, ensuring it gets
+        # priority scheduling and that its resources are reserved
+        # if it ever gets evicted.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      hostNetwork: true
+      tolerations:
+        # Make sure calico-node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      serviceAccountName: calico-node
+      # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
+      # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
+      terminationGracePeriodSeconds: 0
+      initContainers:
+        # This container performs upgrade from host-local IPAM to calico-ipam.
+        # It can be deleted if this is a fresh installation, or if you have already
+        # upgraded to use calico-ipam.
+        - name: upgrade-ipam
+          image: calico/cni:v3.6.0
+          command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
+          env:
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+          volumeMounts:
+            - mountPath: /var/lib/cni/networks
+              name: host-local-net-dir
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: calico/cni:v3.6.0
+          command: ["/install-cni.sh"]
+          env:
+            # Name of the CNI config file to create.
+            - name: CNI_CONF_NAME
+              value: "10-calico.conflist"
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+            # Set the hostname based on the k8s node name.
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # CNI MTU Config variable
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # Prevents the container from sleeping forever.
+            - name: SLEEP
+              value: "false"
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      containers:
+        # Runs node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: calico/node:v3.6.0
+          env:
+            # Use Kubernetes API as the backing datastore.
+            - name: DATASTORE_TYPE
+              value: "kubernetes"
+            # Wait for the datastore.
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            # Set based on the k8s node name.
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Choose the backend to use.
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+            # Cluster type to identify the deployment type
+            - name: CLUSTER_TYPE
+              value: "k8s,bgp"
+            # Auto-detect the BGP IP address.
+            - name: IP
+              value: "autodetect"
+            # Enable IPIP
+            - name: CALICO_IPV4POOL_IPIP
+              value: "Always"
+            # Set MTU for tunnel device used if ipip is enabled
+            - name: FELIX_IPINIPMTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
+            # The default IPv4 pool to create on startup if none exists. Pod IPs will be
+            # chosen from this range. Changing this value after installation will have
+            # no effect. This should fall within --cluster-cidr.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "100.96.0.0/11"
+            # Disable file logging so kubectl logs works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Set Felix logging to "info"
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "info"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 9099
+              host: localhost
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+              - /bin/calico-node
+              - -bird-ready
+              - -felix-ready
+            periodSeconds: 10
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+            - mountPath: /var/lib/calico
+              name: var-lib-calico
+              readOnly: false
+      volumes:
+        # Used by node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        - name: var-lib-calico
+          hostPath:
+            path: /var/lib/calico
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+        # Mount in the directory for host-local IPAM allocations. This is
+        # used when upgrading from host-local to calico-ipam, and can be removed
+        # if not using the upgrade-ipam init container.
+        - name: host-local-net-dir
+          hostPath:
+            path: /var/lib/cni/networks
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-node
+  namespace: kube-system
+
+---
+# Source: calico/templates/calico-kube-controllers.yaml
+# This manifest deploys the Calico node controller.
+# See https://github.com/projectcalico/kube-controllers
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+  labels:
+    k8s-app: calico-kube-controllers
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+spec:
+  # The controller can only have a single active instance.
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+      labels:
+        k8s-app: calico-kube-controllers
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      tolerations:
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      serviceAccountName: calico-kube-controllers
+      containers:
+        - name: calico-kube-controllers
+          image: calico/kube-controllers:v3.6.0
+          env:
+            # Choose which controllers to run.
+            - name: ENABLED_CONTROLLERS
+              value: node
+            - name: DATASTORE_TYPE
+              value: kubernetes
+          readinessProbe:
+            exec:
+              command:
+              - /usr/bin/check-status
+              - -r
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-kube-controllers
+  namespace: kube-system
+---
+# Source: calico/templates/calico-etcd-secrets.yaml
+
+---
+# Source: calico/templates/calico-typha.yaml
+
+---
+# Source: calico/templates/configure-canal.yaml
+`
+)
+
+func NewNetAppBootScript() (string, error) {
+
+	type ScriptValues struct {
+		CalicoYAML              string
+		DefaultStorageClassYAML string
+	}
+
+	values := ScriptValues{
+		CalicoYAML:              calicoYAML,
+		DefaultStorageClassYAML: storageClassYAMLTemplate,
+	}
+
+	return generate("NetAppBootScript", netappBootScript, values)
+}

--- a/pkg/cloud/vsphere/services/userdata/netapp-addons.go
+++ b/pkg/cloud/vsphere/services/userdata/netapp-addons.go
@@ -796,11 +796,13 @@ metadata:
 `
 )
 
-type NetAppBootScriptInput struct {
+// NetApp
+type BootScriptInput struct {
 	Datastore string
 }
 
-func NewNetAppBootScript(input *NetAppBootScriptInput) (string, error) {
+// NetApp
+func NewBootScript(input *BootScriptInput) (string, error) {
 
 	defaultStorageClassYAML, err := generate("DefaultStorageClass", storageClassYAMLTemplate, input)
 	if err != nil {
@@ -817,5 +819,5 @@ func NewNetAppBootScript(input *NetAppBootScriptInput) (string, error) {
 		DefaultStorageClassYAML: defaultStorageClassYAML,
 	}
 
-	return generate("NetAppBootScript", netappBootScript, values)
+	return generate("BootScript", netappBootScript, values)
 }

--- a/pkg/cloud/vsphere/services/userdata/netapp-addons.go
+++ b/pkg/cloud/vsphere/services/userdata/netapp-addons.go
@@ -25,7 +25,7 @@ kubectl apply --kubeconfig=/etc/kubernetes/admin.conf -f netapp-addons/calico.ya
 
 # Default storage class
 cat > netapp-addons/default-storage-class.yaml << EOF
-{{.DefaultStorageClass.yaml}}
+{{.DefaultStorageClassYAML}}
 EOF
 kubectl apply --kubeconfig=/etc/kubernetes/admin.conf -f netapp-addons/default-storage-class.yaml
 
@@ -796,7 +796,16 @@ metadata:
 `
 )
 
-func NewNetAppBootScript() (string, error) {
+type NetAppBootScriptInput struct {
+	Datastore string
+}
+
+func NewNetAppBootScript(input *NetAppBootScriptInput) (string, error) {
+
+	defaultStorageClassYAML, err := generate("DefaultStorageClass", storageClassYAMLTemplate, input)
+	if err != nil {
+		return "", err
+	}
 
 	type ScriptValues struct {
 		CalicoYAML              string
@@ -805,7 +814,7 @@ func NewNetAppBootScript() (string, error) {
 
 	values := ScriptValues{
 		CalicoYAML:              calicoYAML,
-		DefaultStorageClassYAML: storageClassYAMLTemplate,
+		DefaultStorageClassYAML: defaultStorageClassYAML,
 	}
 
 	return generate("NetAppBootScript", netappBootScript, values)

--- a/pkg/cloud/vsphere/services/userdata/netapp-addons.go
+++ b/pkg/cloud/vsphere/services/userdata/netapp-addons.go
@@ -1,5 +1,31 @@
 package userdata
 
+// NetApp
+type BootScriptInput struct {
+	Datastore string
+}
+
+// NetApp
+func NewBootScript(input *BootScriptInput) (string, error) {
+
+	defaultStorageClassYAML, err := generate("DefaultStorageClass", storageClassYAMLTemplate, input)
+	if err != nil {
+		return "", err
+	}
+
+	type ScriptValues struct {
+		CalicoYAML              string
+		DefaultStorageClassYAML string
+	}
+
+	values := ScriptValues{
+		CalicoYAML:              calicoYAML,
+		DefaultStorageClassYAML: defaultStorageClassYAML,
+	}
+
+	return generate("BootScript", netappBootScript, values)
+}
+
 const (
 	netappBootScript = `#!/bin/bash
 
@@ -795,29 +821,3 @@ metadata:
 # Source: calico/templates/configure-canal.yaml
 `
 )
-
-// NetApp
-type BootScriptInput struct {
-	Datastore string
-}
-
-// NetApp
-func NewBootScript(input *BootScriptInput) (string, error) {
-
-	defaultStorageClassYAML, err := generate("DefaultStorageClass", storageClassYAMLTemplate, input)
-	if err != nil {
-		return "", err
-	}
-
-	type ScriptValues struct {
-		CalicoYAML              string
-		DefaultStorageClassYAML string
-	}
-
-	values := ScriptValues{
-		CalicoYAML:              calicoYAML,
-		DefaultStorageClassYAML: defaultStorageClassYAML,
-	}
-
-	return generate("BootScript", netappBootScript, values)
-}


### PR DESCRIPTION
This PR adds netapp specific addons to created clusters:
- Calico CNI
- Default storage class

Note that upstream is using their own fork of cloud-init, containing a `kubeadm` operation, which is just sugar on top of the regular `kubeadm init` or `kubeadm join` commands.

This PR does not use that `kubeadm` cloud-init operation, and instead supplies its own boot script to the first master of every new cluster. This bootscript runs `kubeadm init`, followed by the installation of the addons.