### PR TITLE
NKS-2037 vsphere creds as secret

### DIFF
--- a/pkg/cloud/vsphere/actuators/cluster/actuator.go
+++ b/pkg/cloud/vsphere/actuators/cluster/actuator.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cluster
 
 import (
-	"encoding/base64"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -217,7 +216,7 @@ func (a *Actuator) reconcileCloudConfigSecret(ctx *context.ClusterContext) error
 		ctx.Logger.Error(err, "target cluster is not ready")
 		return &clusterErr.RequeueAfterError{RequeueAfter: config.DefaultRequeue}
 	}
-	// Define the kubeconfig secret for the target cluster.
+	// Define the cloud provider credentials secret for the target cluster.
 	secret := &apiv1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: constants.CloudProviderSecretNamespace,
@@ -225,8 +224,8 @@ func (a *Actuator) reconcileCloudConfigSecret(ctx *context.ClusterContext) error
 		},
 		Type: apiv1.SecretTypeOpaque,
 		StringData: map[string]string{
-			fmt.Sprintf("%s.username", ctx.ClusterConfig.Server): base64.StdEncoding.EncodeToString([]byte(ctx.User())),
-			fmt.Sprintf("%s.password", ctx.ClusterConfig.Server): base64.StdEncoding.EncodeToString([]byte(ctx.Pass())),
+			fmt.Sprintf("%s.username", ctx.ClusterConfig.Server): ctx.User(),
+			fmt.Sprintf("%s.password", ctx.ClusterConfig.Server): ctx.Pass(),
 		},
 	}
 	if _, err := client.Secrets(constants.CloudProviderSecretNamespace).Create(secret); err != nil {


### PR DESCRIPTION
This PR makes CAPV read its vSphere credentials from secret. The name of the secret to be used is passed in as an annotation on the cluster object.

It is still possible to pass in credentials on the cluster object, but if a credential secret exists, those credentials will be preferred.

Also found an upstream bug where the cloud-provider credentials used on the user clusters (and service cluster) were being doubly base64 encoded. This PR fixes that too. 
PR also submitted upstream: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/476.