### PR TITLE
NKS-2143 Fix Trident SC creation

### DIFF
--- a/pkg/cloud/vsphere/provisioner/common/templates.go
+++ b/pkg/cloud/vsphere/provisioner/common/templates.go
@@ -1350,6 +1350,7 @@ cat > setup/backend.json << EOF
   "Endpoint": "https://${ELEMENT_USER}:${ELEMENT_PASSWORD}@${ELEMENT_MVIP}/json-rpc/8.0",
   "SVIP": "${ELEMENT_SVIP}:3260",
   "TenantName": "nks-trident",
+  "backendName": "solidfire",
   "InitiatorIFace": "default",
   "UseCHAP": true,
   "Types": [
@@ -1357,14 +1358,14 @@ cat > setup/backend.json << EOF
           "Type": "Bronze",
           "Qos": {
               "minIOPS": 1000,
-              "maxIOPS": 2000,
-              "burstIOPS": 4000
+              "maxIOPS": 4000,
+              "burstIOPS": 6000
           }
       },
       {
           "Type": "Silver",
           "Qos": {
-              "minIOPS": 4000,
+              "minIOPS": 5000,
               "maxIOPS": 25000,
               "burstIOPS": 40000
           }
@@ -1372,9 +1373,9 @@ cat > setup/backend.json << EOF
       {
           "Type": "Gold",
           "Qos": {
-              "minIOPS": 6000,
-              "maxIOPS": 50000,
-              "burstIOPS": 65000
+              "minIOPS": 15000,
+              "maxIOPS": 180000,
+              "burstIOPS": 200000
           }
       }
   ]
@@ -1391,7 +1392,7 @@ metadata:
 provisioner: netapp.io/trident
 parameters:
   backendType: "solidfire-san"
-  IOPS: "1500"
+  IOPS: "180000"
   fsType: "ext4"
 ---
 apiVersion: storage.k8s.io/v1
@@ -1401,7 +1402,8 @@ metadata:
 provisioner: netapp.io/trident
 parameters:
   backendType: "solidfire-san"
-  IOPS: "1500"
+  storagePools: "solidfire:Silver"
+  IOPS: "25000"
   fsType: "ext4"
 ---
 apiVersion: storage.k8s.io/v1
@@ -1411,7 +1413,7 @@ metadata:
 provisioner: netapp.io/trident
 parameters:
   backendType: "solidfire-san"
-  IOPS: "1500"
+  IOPS: "4000"
   fsType: "ext4"
 EOF
 


### PR DESCRIPTION
We were hardcoding 1500 IOPS for each storage class, resulting in all storage classes being assigned the Bronze QoS.

With this change, we correctly map to the appropriate storage classes. Also updated the IOPS for gold to be as high as possible.

Results from running benchmark test on all storage classes:

vsphere:

==Write==
1+0 records in
1+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 11.6278 s, 92.3 MB/s

==Read==
131072+0 records in
131072+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 10.5312 s, 102 MB/s


solidfire-bronze:

==Write==
1+0 records in
1+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 37.764 s, 28.4 MB/s

==Read==
131072+0 records in
131072+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 37.3188 s, 28.8 MB/s


solidfire-silver:

==Write==
1+0 records in
1+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 5.08065 s, 211 MB/s

==Read==
131072+0 records in
131072+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 3.77708 s, 284 MB/s


solidfire-gold:

==Write==
1+0 records in
1+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 2.99458 s, 359 MB/s

==Read==
131072+0 records in
131072+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 2.6653 s, 403 MB/s