### PR TITLE
NKS-2320 vsphere creds in secrets

### DIFF
--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -246,6 +246,7 @@ func (r *VSphereClusterReconciler) reconcileCloudConfigSecret(ctx *context.Clust
 		credentials[fmt.Sprintf("%s.password", server)] = ctx.Pass()
 	}
 	// Define the kubeconfig secret for the target cluster.
+	// TODO(thorsteinn) Here we are trying to create the cloud provider credentials on the target (user) cluster. We don't have the same wksp-xxx-cluster-xxx namespaces there ofc
 	secret := &apiv1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ctx.VSphereCluster.Spec.CloudProviderConfiguration.Global.SecretNamespace,

--- a/pkg/cloud/vsphere/context/cluster_context.go
+++ b/pkg/cloud/vsphere/context/cluster_context.go
@@ -19,10 +19,11 @@ package context
 import (
 	"context"
 	"fmt"
-	"os"
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/constants"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
@@ -47,6 +48,8 @@ type ClusterContext struct {
 	VSphereCluster *v1alpha2.VSphereCluster
 	Client         client.Client
 	Logger         logr.Logger
+	Username string // NetApp
+	Password string // NetApp
 
 	vsphereClusterPatch client.Patch
 }
@@ -64,6 +67,12 @@ func NewClusterContext(params *ClusterContextParams) (*ClusterContext, error) {
 	}
 	logr = logr.WithName(params.Cluster.APIVersion).WithName(params.Cluster.Namespace).WithName(params.Cluster.Name)
 
+	// NetApp - get credentials from secret
+	username, password, err := getVSphereCredentials(logr, params.Client, params.VSphereCluster)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get vsphere credentials")
+	}
+
 	return &ClusterContext{
 		Context:             parentContext,
 		Cluster:             params.Cluster,
@@ -71,6 +80,8 @@ func NewClusterContext(params *ClusterContextParams) (*ClusterContext, error) {
 		Client:              params.Client,
 		Logger:              logr,
 		vsphereClusterPatch: client.MergeFrom(params.VSphereCluster.DeepCopyObject()),
+		Username: username, // Netapp
+		Password: password, // NetApp
 	}, nil
 }
 
@@ -119,12 +130,12 @@ func (c *ClusterContext) ClusterName() string {
 
 // User returns the username used to access the vSphere endpoint.
 func (c *ClusterContext) User() string {
-	return os.Getenv("VSPHERE_USERNAME")
+	return c.Username
 }
 
 // Pass returns the password used to access the vSphere endpoint.
 func (c *ClusterContext) Pass() string {
-	return os.Getenv("VSPHERE_PASSWORD")
+	return c.Password
 }
 
 // CanLogin returns a flag indicating whether the cluster config has
@@ -147,4 +158,40 @@ func (c *ClusterContext) Patch() error {
 	}
 
 	return nil
+}
+
+// NetApp
+func getVSphereCredentials(logger logr.Logger, c client.Client, vsphereCluster *v1alpha2.VSphereCluster) (string, string, error) {
+
+	secretNamespace := vsphereCluster.Spec.CloudProviderConfiguration.Global.SecretNamespace
+	if secretNamespace == "" {
+		return "", "", fmt.Errorf("secret namespace missing from vsphere cluster")
+	}
+
+	secretName := vsphereCluster.Spec.CloudProviderConfiguration.Global.SecretName
+	if secretName == "" {
+		return "", "", fmt.Errorf("secret name missing from vsphere cluster")
+	}
+
+	logger.V(4).Info("Fetching VSphere credentials from secret", "secret-namespace", secretNamespace, "secret-name", secretName)
+
+	credentialSecret := &apiv1.Secret{}
+	credentialSecretKey := client.ObjectKey{
+		Namespace: secretNamespace,
+		Name:      secretName,
+	}
+	if err := c.Get(context.TODO(), credentialSecretKey, credentialSecret); err != nil {
+		return "", "", errors.Wrapf(err, "error getting credentials secret %s in namespace %s", secretName, secretNamespace)
+	}
+
+	userBuf, userOk := credentialSecret.Data[constants.VSphereCredentialSecretUserKey]
+	passBuf, passOk := credentialSecret.Data[constants.VSphereCredentialSecretPassKey]
+	if !userOk || !passOk {
+		return "", "", fmt.Errorf("improperly formatted credentials secret %q in namespace %s", secretName, secretNamespace)
+	}
+	username, password := string(userBuf), string(passBuf)
+
+	logger.V(4).Info("Found VSphere credentials in secret", "secret-namespace", secretNamespace, "secret-name", secretName)
+
+	return username, password, nil
 }


### PR DESCRIPTION
This PR gets vsphere creds from secret instead of env variables.

WIP since the credentials are not being propagated to the cloud provider secrets on the target clusters correctly.