### PR TITLE
NKS-2317 tag machines

### DIFF
--- a/pkg/cloud/vsphere/context/rest_session.go
+++ b/pkg/cloud/vsphere/context/rest_session.go
@@ -1,0 +1,86 @@
+package context
+
+import (
+	"context"
+	"net/url"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha2"
+)
+
+// NetApp
+var restSessionCache = map[string]RestSession{}
+var restSessionMU sync.Mutex
+
+// NetApp
+type RestSession struct {
+	*rest.Client
+}
+
+// NetApp
+func getOrCreateCachedRESTSession(ctx *MachineContext) (*RestSession, error) {
+	restSessionMU.Lock()
+	defer restSessionMU.Unlock()
+
+	server := ctx.VSphereCluster.Spec.Server
+	datacenter := ctx.VSphereMachine.Spec.Datacenter
+	sessionKey := server + ctx.User() + datacenter
+
+	if session, ok := restSessionCache[sessionKey]; ok {
+		if ok := session.IsActive(); ok {
+			ctx.Logger.V(4).Info("using cached vSphere REST client session", "server", server, "user", ctx.User())
+			return &session, nil
+		}
+	}
+
+	soapURL, err := soap.ParseURL(server)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error parsing vSphere URL %q", server)
+	}
+	if soapURL == nil {
+		return nil, errors.Errorf("error parsing vSphere URL %q", server)
+	}
+
+	soapClient := soap.NewClient(soapURL, true)
+	vimClient, err := vim25.NewClient(ctx, soapClient)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error setting up new vSphere SOAP client")
+	}
+
+	ctx.Logger.V(2).Info("creating new vSphere REST client session", "server", server, "user", ctx.User())
+	restClient := rest.NewClient(vimClient)
+	if err := restClient.Login(ctx, url.UserPassword(ctx.User(), ctx.Pass())); err != nil {
+		return nil, errors.Wrapf(err, "error logging in with REST client for user %q", ctx.User())
+	}
+
+	session := RestSession{Client: restClient}
+
+	session.UserAgent = v1alpha2.GroupVersion.String()
+
+	// Cache the session.
+	restSessionCache[sessionKey] = session
+	ctx.Logger.V(2).Info("cached vSphere REST client session", "server", server, "user", ctx.User())
+
+	return &session, nil
+}
+
+// NetApp
+func (s *RestSession) IsActive() bool {
+
+	// NOTE: Rest client does not expose an IsActive check out of the box. Rolling our own rudimentary one.
+
+	tm := tags.NewManager(s.Client)
+
+	_, err := tm.GetTags(context.TODO())
+	if err != nil {
+		return false
+	}
+
+	return true
+}

--- a/pkg/cloud/vsphere/services/govmomi/service.go
+++ b/pkg/cloud/vsphere/services/govmomi/service.go
@@ -18,7 +18,7 @@ package govmomi
 
 import (
 	"encoding/base64"
-	
+
 	"github.com/pkg/errors"
 
 	"github.com/vmware/govmomi/property"
@@ -115,7 +115,8 @@ func (vms *VMService) ReconcileVM(ctx *context.MachineContext) (infrav1.VirtualM
 
 	// NetApp
 	if err := vms.reconcileTags(ctx); err != nil {
-		// Just log the error?
+		// Just log the error
+		ctx.Logger.Error(err, "error reconciling tags")
 	}
 
 	vm.State = infrav1.VirtualMachineStateReady
@@ -156,6 +157,7 @@ func (vms *VMService) DestroyVM(ctx *context.MachineContext) (infrav1.VirtualMac
 			// NetApp
 			if err := vms.deleteTags(ctx); err != nil {
 				// Just log the error
+				ctx.Logger.Error(err, "error deleting tags")
 			}
 
 			return vm, nil
@@ -433,12 +435,18 @@ func (vms *VMService) reconcileTags(ctx *context.MachineContext) error {
 	if err != nil {
 		return err
 	}
-	tags.TagNKSMachine(ctx, vm)
+	err = tags.TagNKSMachine(ctx, vm)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
 // NetApp
 func (vms *VMService) deleteTags(ctx *context.MachineContext) error {
-	tags.CleanupNKSTags(ctx)
+	err := tags.CleanupNKSTags(ctx)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/cloud/vsphere/services/govmomi/tags/nks-tags.go
+++ b/pkg/cloud/vsphere/services/govmomi/tags/nks-tags.go
@@ -26,13 +26,13 @@ func TagNKSMachine(ctx *context.MachineContext, vm *object.VirtualMachine) error
 
 	ctx.Logger.V(4).Info("tagging VM with cluster information")
 	if err := tagWithClusterInfo(ctx, tagManager, vm.Reference(), workspaceID, clusterID, ctx.Cluster.Name); err != nil {
-		return errors.Wrapf(err, "could not tag VM with cluster information for machine %q: %v", ctx.Machine.Name)
+		return errors.Wrapf(err, "could not tag VM with cluster information for machine %q", ctx.Machine.Name)
 	}
 
 	if isServiceCluster {
 		ctx.Logger.V(4).Info("tagging VM as service cluster machine")
 		if err := tagAsServiceCluster(ctx, tagManager, vm.Reference()); err != nil {
-			return errors.Wrapf(err, "could not tag VM as service cluster machine for machine %q: %v", ctx.Machine.Name)
+			return errors.Wrapf(err, "could not tag VM as service cluster machine for machine %q", ctx.Machine.Name)
 		}
 	}
 
@@ -48,13 +48,13 @@ func CleanupNKSTags(ctx *context.MachineContext) error {
 
 	ctx.Logger.V(4).Info("cleaning up cluster information tag and category", "cluster", ctx.Cluster.Name)
 	if err := deleteClusterInfoTagAndCategory(ctx, tagManager, workspaceID, clusterID, ctx.Cluster.Name); err != nil {
-		return errors.Wrapf(err, "could not clean up cluster information tag and category for cluster %q: %v", ctx.Cluster.Name)
+		return errors.Wrapf(err, "could not clean up cluster information tag and category for cluster %q", ctx.Cluster.Name)
 	}
 
 	if isServiceCluster {
 		ctx.Logger.V(4).Info("cleaning up service cluster tag and category", "cluster", ctx.Cluster.Name)
 		if err := deleteServiceClusterTagAndCategory(ctx, tagManager); err != nil {
-			return errors.Wrapf(err, "could not clean up service cluster tag and category for cluster %q: %v", ctx.Cluster.Name)
+			return errors.Wrapf(err, "could not clean up service cluster tag and category for cluster %q", ctx.Cluster.Name)
 		}
 	}
 

--- a/pkg/cloud/vsphere/services/govmomi/tags/nks-tags.go
+++ b/pkg/cloud/vsphere/services/govmomi/tags/nks-tags.go
@@ -1,0 +1,244 @@
+package tags
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vapi/tags"
+	"github.com/vmware/govmomi/vim25/types"
+	"k8s.io/klog"
+
+	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/context"
+)
+
+// NetApp
+const (
+	categoryName               = "NKS"
+	clusterInfoTagNameTemplate = "nks.workspaceid.%s.clusterid.%s.clustername.%s"
+	serviceClusterTagName      = "nks.service.cluster"
+)
+
+// NetApp
+// TagNKSMachine tags the machine with NKS vSphere tags. If the tags do not exist, they are created.
+// This is done in a best-effort manner. In case of errors, simply log and continue
+func TagNKSMachine(ctx *context.MachineContext, vm *object.VirtualMachine) {
+
+	tagManager := tags.NewManager(ctx.RestSession.Client)
+	clusterID, workspaceID, isServiceCluster := ctx.GetNKSClusterInfo()
+
+	ctx.Logger.V(4).Info("tagging VM with cluster information")
+	if err := tagWithClusterInfo(ctx, tagManager, vm.Reference(), workspaceID, clusterID, ctx.Cluster.Name); err != nil {
+		klog.Errorf("could not tag VM with cluster information for machine %q: %v", ctx.Machine.Name, err)
+	}
+
+	if isServiceCluster {
+		ctx.Logger.V(4).Info("tagging VM as service cluster machine")
+		if err := tagAsServiceCluster(ctx, tagManager, vm.Reference()); err != nil {
+			klog.Errorf("could not tag VM as service cluster machine for machine %q: %v", ctx.Machine.Name, err)
+		}
+	}
+}
+
+// NetApp
+// CleanupNKSTags deletes vSphere tags and tag categories that may be associated with the machine - if they are not attached to any objects anymore
+// This is done in a best-effort manner. In case of errors, simply log and continue
+func CleanupNKSTags(ctx *context.MachineContext) {
+
+	tagManager := tags.NewManager(ctx.RestSession.Client)
+	clusterID, workspaceID, isServiceCluster := ctx.GetNKSClusterInfo()
+
+	ctx.Logger.V(4).Info("cleaning up cluster information tag and category", "cluster", ctx.Cluster.Name)
+	if err := deleteClusterInfoTagAndCategory(ctx, tagManager, workspaceID, clusterID, ctx.Cluster.Name); err != nil {
+		klog.Errorf("could not clean up cluster information tag and category for cluster %q: %v", ctx.Cluster.Name, err)
+	}
+
+	if isServiceCluster {
+		ctx.Logger.V(4).Info("cleaning up service cluster tag and category", "cluster", ctx.Cluster.Name)
+		if err := deleteServiceClusterTagAndCategory(ctx, tagManager); err != nil {
+			klog.Errorf("could not clean up service cluster tag and category for cluster %q: %v", ctx.Cluster.Name, err)
+		}
+	}
+
+}
+
+// NetApp
+func tagWithClusterInfo(ctx *context.MachineContext, tm *tags.Manager, moref types.ManagedObjectReference, workspaceID string, clusterID string, clusterName string) error {
+
+	tagName := fmt.Sprintf(clusterInfoTagNameTemplate, workspaceID, clusterID, clusterName)
+
+	tag, err := getOrCreateNKSTag(ctx, tm, tagName)
+	if err != nil {
+		return err
+	}
+
+	err = tm.AttachTag(ctx, tag.ID, moref)
+	if err != nil {
+		return errors.Wrapf(err, "could not attach tag %s to object", tag.Name)
+	}
+
+	return nil
+}
+
+// NetApp
+// deleteClusterInfoTagAndCategory deletes the cluster info tag if there are no subjects tied to the tag, i.e. no objects are tagged with that tag
+// It also deletes the tag category if there are no tags left in the category
+func deleteClusterInfoTagAndCategory(ctx *context.MachineContext, tm *tags.Manager, workspaceID string, clusterID string, clusterName string) error {
+
+	tagName := fmt.Sprintf(clusterInfoTagNameTemplate, workspaceID, clusterID, clusterName)
+
+	tag, err := tm.GetTag(ctx, tagName)
+	if err != nil {
+		return errors.Wrapf(err, "could not get tag with name %s", tagName)
+	}
+
+	return deleteNKSTag(ctx, tm, tag)
+}
+
+// NetApp
+func tagAsServiceCluster(ctx *context.MachineContext, tm *tags.Manager, moref types.ManagedObjectReference) error {
+
+	tag, err := getOrCreateNKSTag(ctx, tm, serviceClusterTagName)
+	if err != nil {
+		return err
+	}
+
+	err = tm.AttachTag(ctx, tag.ID, moref)
+	if err != nil {
+		return errors.Wrapf(err, "could not attach tag %s to object", tag.Name)
+	}
+
+	return nil
+}
+
+// NetApp
+// deleteServiceClusterTagAndCategory deletes the service cluster tag if there are no subjects tied to the tag, i.e. no objects are tagged with that tag
+// It also deletes the tag category if there are no tags left in the category
+func deleteServiceClusterTagAndCategory(ctx *context.MachineContext, tm *tags.Manager) error {
+
+	tag, err := tm.GetTag(ctx, serviceClusterTagName)
+	if err != nil {
+		return errors.Wrapf(err, "could not get tag with name %s", serviceClusterTagName)
+	}
+
+	return deleteNKSTag(ctx, tm, tag)
+}
+
+// NetApp
+func getOrCreateNKSTag(ctx *context.MachineContext, tm *tags.Manager, tagName string) (*tags.Tag, error) {
+
+	tag, err := tm.GetTag(ctx, tagName)
+	if err == nil && tag != nil {
+		return tag, nil
+	}
+
+	nksCategory, err := getOrCreateNKSTagCategory(ctx, tm)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get NKS tag category")
+	}
+
+	newTag := &tags.Tag{
+		Name:        tagName,
+		Description: "NKS tag",
+		CategoryID:  nksCategory.ID,
+	}
+
+	ctx.Logger.V(4).Info("creating vSphere tag", "tag", newTag.Name)
+	_, err = tm.CreateTag(ctx, newTag)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not create tag %s", newTag)
+	}
+
+	tag, err = tm.GetTag(ctx, tagName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get tag with name %s", tagName)
+	}
+
+	return tag, nil
+}
+
+// NetApp
+func getOrCreateNKSTagCategory(ctx *context.MachineContext, tm *tags.Manager) (*tags.Category, error) {
+
+	category, err := tm.GetCategory(ctx, categoryName)
+	if err == nil && category != nil {
+		return category, nil
+	}
+
+	newCategory := &tags.Category{
+		Name:        categoryName,
+		Description: "NKS tag category",
+		Cardinality: "MULTIPLE",
+		AssociableTypes: []string{
+			"Folder",
+			"VirtualMachine",
+		},
+	}
+
+	ctx.Logger.V(4).Info("creating vSphere tag category", "category", newCategory.Name)
+	_, err = tm.CreateCategory(ctx, newCategory)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not create tag category %s", newCategory)
+	}
+
+	category, err = tm.GetCategory(ctx, categoryName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get tag category with name %s", categoryName)
+	}
+
+	return category, nil
+}
+
+// NetApp
+func deleteNKSTag(ctx *context.MachineContext, tm *tags.Manager, tag *tags.Tag) error {
+
+	attachedObjects, err := tm.ListAttachedObjects(ctx, tag.ID)
+	if err != nil {
+		return errors.Wrapf(err, "could not list attached objects for tag with name %s", tag.Name)
+	}
+
+	if len(attachedObjects) == 0 {
+
+		ctx.Logger.V(4).Info("deleting vSphere tag", "tag", tag.Name)
+		err := tm.DeleteTag(ctx, tag)
+		if err != nil {
+			return errors.Wrapf(err, "could not delete tag with name %s")
+		}
+
+		category, err := tm.GetCategory(ctx, tag.CategoryID)
+		if err != nil {
+			return errors.Wrapf(err, "could not get category with ID %s", tag.CategoryID)
+		}
+
+		err = deleteNKSTagCategory(ctx, tm, category)
+		if err != nil {
+			return errors.Wrapf(err, "could not delete category for tag %s with name %s", tag.Name, category.Name)
+		}
+
+		return nil
+	}
+
+	ctx.Logger.V(4).Info("will not delete vSphere tag, still in use", "tag", tag.Name)
+	return nil
+}
+
+// NetApp
+func deleteNKSTagCategory(ctx *context.MachineContext, tm *tags.Manager, category *tags.Category) error {
+
+	tagsInCategory, err := tm.GetTagsForCategory(ctx, category.Name)
+	if err != nil {
+		return errors.Wrapf(err, "could not get tags for category with name %s", category.Name)
+	}
+
+	if len(tagsInCategory) == 0 {
+		ctx.Logger.V(4).Info("deleting vSphere tag category", "category", category.Name)
+		err := tm.DeleteCategory(ctx, category)
+		if err != nil {
+			return errors.Wrapf(err, "could not delete category with name %s", category.Name)
+		}
+		return nil
+	}
+
+	ctx.Logger.V(4).Info("will not delete vSphere tag category, still in use", "category", category.Name)
+	return nil
+}

--- a/pkg/cloud/vsphere/services/govmomi/tags/nks-tags.go
+++ b/pkg/cloud/vsphere/services/govmomi/tags/nks-tags.go
@@ -196,29 +196,29 @@ func deleteNKSTag(ctx *context.MachineContext, tm *tags.Manager, tag *tags.Tag) 
 		return errors.Wrapf(err, "could not list attached objects for tag with name %s", tag.Name)
 	}
 
-	if len(attachedObjects) == 0 {
-
-		ctx.Logger.V(4).Info("deleting vSphere tag", "tag", tag.Name)
-		err := tm.DeleteTag(ctx, tag)
-		if err != nil {
-			return errors.Wrapf(err, "could not delete tag with name %s")
-		}
-
-		category, err := tm.GetCategory(ctx, tag.CategoryID)
-		if err != nil {
-			return errors.Wrapf(err, "could not get category with ID %s", tag.CategoryID)
-		}
-
-		err = deleteNKSTagCategory(ctx, tm, category)
-		if err != nil {
-			return errors.Wrapf(err, "could not delete category for tag %s with name %s", tag.Name, category.Name)
-		}
-
+	if len(attachedObjects) != 0 {
+		ctx.Logger.V(4).Info("will not delete vSphere tag, still in use", "tag", tag.Name)
 		return nil
 	}
 
-	ctx.Logger.V(4).Info("will not delete vSphere tag, still in use", "tag", tag.Name)
+	ctx.Logger.V(4).Info("deleting vSphere tag", "tag", tag.Name)
+	err = tm.DeleteTag(ctx, tag)
+	if err != nil {
+		return errors.Wrapf(err, "could not delete tag with name %s")
+	}
+
+	category, err := tm.GetCategory(ctx, tag.CategoryID)
+	if err != nil {
+		return errors.Wrapf(err, "could not get category with ID %s", tag.CategoryID)
+	}
+
+	err = deleteNKSTagCategory(ctx, tm, category)
+	if err != nil {
+		return errors.Wrapf(err, "could not delete category for tag %s with name %s", tag.Name, category.Name)
+	}
+
 	return nil
+
 }
 
 // NetApp
@@ -229,15 +229,16 @@ func deleteNKSTagCategory(ctx *context.MachineContext, tm *tags.Manager, categor
 		return errors.Wrapf(err, "could not get tags for category with name %s", category.Name)
 	}
 
-	if len(tagsInCategory) == 0 {
-		ctx.Logger.V(4).Info("deleting vSphere tag category", "category", category.Name)
-		err := tm.DeleteCategory(ctx, category)
-		if err != nil {
-			return errors.Wrapf(err, "could not delete category with name %s", category.Name)
-		}
+	if len(tagsInCategory) != 0 {
+		ctx.Logger.V(4).Info("will not delete vSphere tag category, still in use", "category", category.Name)
 		return nil
 	}
 
-	ctx.Logger.V(4).Info("will not delete vSphere tag category, still in use", "category", category.Name)
+	ctx.Logger.V(4).Info("deleting vSphere tag category", "category", category.Name)
+	err = tm.DeleteCategory(ctx, category)
+	if err != nil {
+		return errors.Wrapf(err, "could not delete category with name %s", category.Name)
+	}
 	return nil
+
 }

--- a/pkg/cloud/vsphere/services/govmomi/vcenter/clone.go
+++ b/pkg/cloud/vsphere/services/govmomi/vcenter/clone.go
@@ -92,7 +92,7 @@ func Clone(ctx *context.MachineContext, bootstrapData []byte) error {
 
 	spec := types.VirtualMachineCloneSpec{
 		Config: &types.VirtualMachineConfigSpec{
-			Annotation: ctx.String(),
+			Annotation: ctx.GetMachineAnnotation(), // NetApp
 			// Assign the clone's InstanceUUID the value of the Kubernetes Machine
 			// object's UID. This allows lookup of the cloned VM prior to knowing
 			// the VM's UUID.


### PR DESCRIPTION
This PR adds tagging of VMs in vSphere.

It just includes the tags we had previously - i.e. `"nks.workspaceid.%s.clusterid.%s.clustername.%s"` and `"nks.service.cluster"`.

The tagging is done "best effort", in case of an error we just log it and continue. A new annotation is also added to the VMs at clone time.

Adding more / better tags to be handled separately. We need to pass more info down into the cluster objects, e.g. the actual name of the cluster (instead of the instance ID), and perhaps the on-premise region name.