### PR TITLE
update: Jenkins Pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     APP_NAME   = 'cluster-api-provider-vsphere'
     REPOSITORY = "${ORG}/${APP_NAME}"
     GO111MODULE = 'off'
-    GOPATH = '/home/jenkins/go'
+    GOPATH = "${WORKSPACE}/go"
   }
 
   stages {
@@ -21,7 +21,7 @@ pipeline {
     stage('generate'){
       steps {
         container('golang') {
-          dir('/home/jenkins/go/src/github.com/NetApp/cluster-api-provider-vsphere') {
+          dir("${GOPATH}/src/github.com/NetApp/cluster-api-provider-vsphere") {
             checkout scm
             sh('go generate ./pkg/... ./cmd/...')
           }
@@ -32,7 +32,7 @@ pipeline {
     stage('manifests'){
       steps {
         container('golang') {
-          dir('/home/jenkins/go/src/github.com/NetApp/cluster-api-provider-vsphere') {
+          dir("${GOPATH}/src/github.com/NetApp/cluster-api-provider-vsphere") {
             sh('go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all')
           }
         }


### PR DESCRIPTION
Latest updates to the Jenkins Kubernetes plugins change from using `/jenkins/home` for workspaces into using `/jenkins/home/agent`

We're hardcoding `/jenkins/home/go` as the go path which seems to be no longer writable after the update.
This change should fix builds from breaking once we update