### PR TITLE
NKS-2451 Networking configuration

### DIFF
--- a/pkg/cloud/vsphere/util/constants.go
+++ b/pkg/cloud/vsphere/util/constants.go
@@ -80,7 +80,6 @@ network:
 
 // NetApp
 // TODO(thorsteinnth) Handle more networking configuration options - or see if we can trust v2 being parsed into ENI configuration
-// TODO(thorsteinnth) Handle more NICs - remove hardcoding of NIC name, where to get it from?
 const metadataFormatV1 = `
 instance-id: "{{ .Hostname }}"
 local-hostname: "{{ .Hostname }}"

--- a/pkg/cloud/vsphere/util/constants.go
+++ b/pkg/cloud/vsphere/util/constants.go
@@ -77,3 +77,38 @@ network:
   {{- end }}
   {{- end }}
 `
+
+// NetApp
+// TODO(thorsteinnth) Handle more networking configuration options - or see if we can trust v2 being parsed into ENI configuration
+// TODO(thorsteinnth) Handle more NICs - remove hardcoding of NIC name, where to get it from?
+const metadataFormatV1 = `
+instance-id: "{{ .Hostname }}"
+local-hostname: "{{ .Hostname }}"
+network:
+  version: 1
+  config:
+    {{- range $i, $net := .Devices }}
+    - type: physical
+      name: ens160
+      mac_address: "{{ $net.MACAddr }}" 
+      subnets:
+	  {{- if $net.DHCP4 }}
+        - type: dhcp4
+      {{- end }}
+      {{- if $net.IPAddrs }}
+      {{- range $net.IPAddrs }}
+        - type: static
+          address: "{{ . }}"
+          {{- if $net.Gateway4 }}
+          gateway: "{{ $net.Gateway4 }}"
+          {{- end }}
+          {{- if nameservers $net }}
+          dns_nameservers:
+            {{- range $net.Nameservers }}
+              - "{{ . }}"
+            {{- end }}
+          {{- end }}
+      {{- end }}
+      {{- end }}
+    {{- end }}
+`

--- a/pkg/cloud/vsphere/util/constants.go
+++ b/pkg/cloud/vsphere/util/constants.go
@@ -89,7 +89,7 @@ network:
   config:
     {{- range $i, $net := .Devices }}
     - type: physical
-      name: ens160
+      name: {{ mapNetworkToNICName $net }}
       mac_address: "{{ $net.MACAddr }}" 
       subnets:
 	  {{- if $net.DHCP4 }}

--- a/pkg/cloud/vsphere/util/constants.go
+++ b/pkg/cloud/vsphere/util/constants.go
@@ -79,7 +79,7 @@ network:
 `
 
 // NetApp
-// TODO(thorsteinnth) Handle more networking configuration options - or see if we can trust v2 being parsed into ENI configuration
+// TODO(thorsteinnth) Handle more networking configuration options
 const metadataFormatV1 = `
 instance-id: "{{ .Hostname }}"
 local-hostname: "{{ .Hostname }}"
@@ -88,7 +88,7 @@ network:
   config:
     {{- range $i, $net := .Devices }}
     - type: physical
-      name: {{ mapNetworkToNICName $net }}
+      name: id{{ $i }}
       mac_address: "{{ $net.MACAddr }}" 
       subnets:
 	  {{- if $net.DHCP4 }}

--- a/pkg/cloud/vsphere/util/machines.go
+++ b/pkg/cloud/vsphere/util/machines.go
@@ -19,6 +19,7 @@ package util
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net"
 	"text/template"
 
@@ -156,13 +157,19 @@ func GetMachineMetadata(machine infrav1.VSphereMachine, networkStatus ...infrav1
 		}
 	}
 
+	// NetApp
+	// TODO(thorsteinnth) Remove once we handle more than one NIC
+	if len(devices) > 1 {
+		return nil, fmt.Errorf("more than one NIC on machine - unsupported")
+	}
+
 	buf := &bytes.Buffer{}
 	tpl := template.Must(template.New("t").Funcs(
 		template.FuncMap{
 			"nameservers": func(spec infrav1.NetworkDeviceSpec) bool {
 				return len(spec.Nameservers) > 0 || len(spec.SearchDomains) > 0
 			},
-		}).Parse(metadataFormat))
+		}).Parse(metadataFormatV1)) // NetApp
 	if err := tpl.Execute(buf, struct {
 		Hostname string
 		Devices  []infrav1.NetworkDeviceSpec


### PR DESCRIPTION
This PR adds support for v1 of cloud-init's networking configuration (ENI).

It decides which template format to use based on an annotation on the VSphereMachine object. If this annotation is missing, it defaults to version 1.

Note:
It turns out that v1 of the networking configuration is able to rename NICs based on MAC addresses, so the NIC to network name mapping is unnecessary.