### PR TITLE
NKS-2464 wait for IP on given network

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,5 +92,26 @@ pipeline {
       }
     }
 
+    stage('publish: release') {
+      when {
+        branch 'release-*'
+      }
+      environment {
+        GIT_COMMIT_SHORT = sh(
+                script: "printf \$(git rev-parse --short ${GIT_COMMIT})",
+                returnStdout: true
+        ).trim()
+      }
+      steps {
+        container('builder-base') {
+          script {
+            docker.withRegistry("https://${DOCKER_REGISTRY}", "gcr:${ORG}") {
+              image.push("netapp-${GIT_COMMIT_SHORT}")
+            }
+          }
+        }
+      }
+    }
+
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     APP_NAME   = 'cluster-api-provider-vsphere'
     REPOSITORY = "${ORG}/${APP_NAME}"
     GO111MODULE = 'off'
-    GOPATH = '${WORKSPACE}/go'
+    GOPATH = "${WORKSPACE}/go"
   }
 
   stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
     stage('generate'){
       steps {
         container('golang') {
-          dir('${GOPATH}/src/github.com/NetApp/cluster-api-provider-vsphere') {
+          dir("${GOPATH}/src/github.com/NetApp/cluster-api-provider-vsphere") {
             checkout scm
             sh('go generate ./pkg/... ./cmd/...')
           }
@@ -32,7 +32,7 @@ pipeline {
     stage('manifests'){
       steps {
         container('golang') {
-          dir('${GOPATH}/src/github.com/NetApp/cluster-api-provider-vsphere') {
+          dir("${GOPATH}/src/github.com/NetApp/cluster-api-provider-vsphere") {
             sh('go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all')
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     APP_NAME   = 'cluster-api-provider-vsphere'
     REPOSITORY = "${ORG}/${APP_NAME}"
     GO111MODULE = 'off'
-    GOPATH = '/home/jenkins/go'
+    GOPATH = '${WORKSPACE}/go'
   }
 
   stages {
@@ -21,7 +21,7 @@ pipeline {
     stage('generate'){
       steps {
         container('golang') {
-          dir('/home/jenkins/go/src/github.com/NetApp/cluster-api-provider-vsphere') {
+          dir('${GOPATH}/src/github.com/NetApp/cluster-api-provider-vsphere') {
             checkout scm
             sh('go generate ./pkg/... ./cmd/...')
           }
@@ -32,7 +32,7 @@ pipeline {
     stage('manifests'){
       steps {
         container('golang') {
-          dir('/home/jenkins/go/src/github.com/NetApp/cluster-api-provider-vsphere') {
+          dir('${GOPATH}/src/github.com/NetApp/cluster-api-provider-vsphere') {
             sh('go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all')
           }
         }

--- a/pkg/cloud/vsphere/provisioner/common/templates.go
+++ b/pkg/cloud/vsphere/provisioner/common/templates.go
@@ -502,8 +502,12 @@ systemctl start docker || true
 
 sysctl net.bridge.bridge-nf-call-iptables=1
 
-` +
+#` +
 	"PUBLICIP=`ip route get 8.8.8.8 | awk '{for(i=1; i<=NF; i++) if($i~/src/) print $(i+1)}'`" + `
+
+# NetApp
+` +
+	"PUBLICIP=`ip -4 addr show ens160 | grep -oP '(?<=inet\\s)\\d+(\\.\\d+){3}'`" + `
 
 cat > /etc/systemd/system/kubelet.service.d/20-cloud.conf << EOF
 [Service]
@@ -933,11 +937,18 @@ sed -i '/ swap / s/^/#/' /etc/fstab
 systemctl enable docker
 systemctl start docker
 
-` +
+#` +
 	"PRIVATEIP=`ip route get 8.8.8.8 | awk '{for(i=1; i<=NF; i++) if($i~/src/) print $(i+1)}'`" + `
+#echo $PRIVATEIP > /tmp/.ip
+#` +
+	"PUBLICIP=`ip route get 8.8.8.8 | awk '{for(i=1; i<=NF; i++) if($i~/src/) print $(i+1)}'`" + `
+
+# NetApp
+` +
+	"PRIVATEIP=`ip -4 addr show ens160 | grep -oP '(?<=inet\\s)\\d+(\\.\\d+){3}'`" + `
 echo $PRIVATEIP > /tmp/.ip
 ` +
-	"PUBLICIP=`ip route get 8.8.8.8 | awk '{for(i=1; i<=NF; i++) if($i~/src/) print $(i+1)}'`" + `
+	"PUBLICIP=`ip -4 addr show ens160 | grep -oP '(?<=inet\\s)\\d+(\\.\\d+){3}'`" + `
 
 cat > /etc/systemd/system/kubelet.service.d/20-cloud.conf << EOF
 [Service]

--- a/pkg/cloud/vsphere/provisioner/govmomi/update.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/update.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/vmware/govmomi/vapi/tags"
+	"strings"
 	"time"
 
 	"github.com/vmware/govmomi/object"
@@ -88,7 +89,13 @@ func getPrimaryNetworkName(machine *clusterv1.Machine) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("primary network annotation missing on machine %q", machine.Name)
 	}
-	return networkName, nil
+	return stripResourcePath(networkName), nil
+}
+
+// NetApp
+func stripResourcePath(resourceWithPath string) string {
+	splitResource := strings.Split(resourceWithPath, "/")
+	return splitResource[len(splitResource)-1]
 }
 
 // Updates the detected IP for the machine and updates the cluster object signifying a change in the infrastructure

--- a/pkg/cloud/vsphere/provisioner/govmomi/update.go
+++ b/pkg/cloud/vsphere/provisioner/govmomi/update.go
@@ -63,17 +63,10 @@ func (pv *Provisioner) Update(ctx context.Context, cluster *clusterv1.Cluster, m
 		klog.V(4).Info("actuator.Update() - did not find IP, waiting on IP")
 		vm := object.NewVirtualMachine(s.session.Client, vmref)
 		var vmIP string
-		macToIPMap, err := vm.WaitForNetIP(updatectx, true, "ethernet-0")
+		// NetApp
+		vmIP, err := WaitForNetworkIP(updatectx, vm, true, "NetApp HCI VDS 01-HCI_Internal_NKS_Workload")
 		if err != nil {
 			return err
-		}
-
-		// macToIPMap will contain only one MAC address, the one for ethernet-0
-		// Return the first (and only) IPv4 address found
-		for _, ips := range macToIPMap {
-			for _, ip := range ips {
-				vmIP = ip
-			}
 		}
 
 		pv.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "IP Detected", "IP %s detected for Virtual Machine %s", vmIP, vm.Name())

--- a/pkg/cloud/vsphere/utils/utils.go
+++ b/pkg/cloud/vsphere/utils/utils.go
@@ -47,7 +47,7 @@ func GetIP(_ *clusterv1.Cluster, machine *clusterv1.Machine) (string, error) {
 	if machine.ObjectMeta.Annotations == nil {
 		return "", errors.New("could not get IP")
 	}
-	if ip, ok := machine.ObjectMeta.Annotations[constants.VmIpAnnotationKey]; ok {
+	if ip, ok := machine.ObjectMeta.Annotations[constants.VmIpAnnotationKey]; ok && ip != "" { // NetApp
 		return ip, nil
 	}
 	return "", errors.New("could not get IP")


### PR DESCRIPTION
This PR adds support for multiple NICs connected to different networks (workload/data).

- gets the name of the primary (workload) network from an annotation on the machine object
- waits explicitly for an IP on that network to assign to the machine (as the vm-ip-address annotation)
- gets the IP from the ens160 NIC to supply to kubeadm during master and node startup - this is the NIC connected to the workload network