### PR TITLE
NKS-2650 add cluster creator to the note section in vCenter

### DIFF
--- a/pkg/cloud/vsphere/context/machine_context.go
+++ b/pkg/cloud/vsphere/context/machine_context.go
@@ -40,7 +40,7 @@ type MachineContext struct {
 	Machine        *clusterv1.Machine
 	VSphereMachine *v1alpha2.VSphereMachine
 	Session        *Session
-	RestSession *RestSession // NetApp
+	RestSession    *RestSession // NetApp
 
 	vsphereMachinePatch client.Patch
 }
@@ -136,15 +136,17 @@ func (c *MachineContext) Patch() error {
 // NetApp
 // GetNKSClusterInfo returns NKS information on the cluster that the machine is a part of
 // Returns clusterID, workspaceID, isServiceCluster
-func (c *MachineContext) GetNKSClusterInfo() (string, string, bool) {
+func (c *MachineContext) GetNKSClusterInfo() (string, string, string, bool) {
 
 	const ClusterIdLabel = "hci.nks.netapp.com/cluster"
 	const WorkspaceIdLabel = "hci.nks.netapp.com/workspace"
 	const ClusterRoleLabel = "hci.nks.netapp.com/role"
+	const CreatorName = "creator"
 	const ServiceClusterRole = "service-cluster"
 
 	var workspaceID = ""
 	var clusterID = ""
+	var creator = ""
 	var isServiceCluster bool
 
 	if val, ok := c.Cluster.Labels[WorkspaceIdLabel]; ok {
@@ -153,18 +155,21 @@ func (c *MachineContext) GetNKSClusterInfo() (string, string, bool) {
 	if val, ok := c.Cluster.Labels[ClusterIdLabel]; ok {
 		clusterID = val
 	}
+	if val, ok := c.Cluster.Annotations[CreatorName]; ok {
+		creator = val
+	}
 	if val, ok := c.Cluster.Labels[ClusterRoleLabel]; ok {
 		if val == ServiceClusterRole {
 			isServiceCluster = true
 		}
 	}
 
-	return clusterID, workspaceID, isServiceCluster
+	return clusterID, workspaceID, creator, isServiceCluster
 }
 
 // NetApp
 func (c *MachineContext) GetMachineAnnotation() string {
 	// TODO: At this point we do not know if it is a service cluster - need better communication of that
-	clusterID, workspaceID, _ := c.GetNKSClusterInfo()
-	return fmt.Sprintf("VM is part of NKS kubernetes cluster %s with cluster ID %s in workspace with ID %s", c.Cluster.Name, clusterID, workspaceID)
+	clusterID, workspaceID, creator, _ := c.GetNKSClusterInfo()
+	return fmt.Sprintf("VM is part of NKS kubernetes cluster %s with cluster ID %s in workspace with ID %s created by %s", c.Cluster.Name, clusterID, workspaceID, creator)
 }

--- a/pkg/cloud/vsphere/context/machine_context.go
+++ b/pkg/cloud/vsphere/context/machine_context.go
@@ -135,7 +135,7 @@ func (c *MachineContext) Patch() error {
 
 // NetApp
 // GetNKSClusterInfo returns NKS information on the cluster that the machine is a part of
-// Returns clusterID, workspaceID, isServiceCluster
+// Returns clusterID, workspaceID, creator, isServiceCluster
 func (c *MachineContext) GetNKSClusterInfo() (string, string, string, bool) {
 
 	const ClusterIdLabel = "hci.nks.netapp.com/cluster"

--- a/pkg/cloud/vsphere/services/govmomi/tags/nks-tags.go
+++ b/pkg/cloud/vsphere/services/govmomi/tags/nks-tags.go
@@ -22,7 +22,7 @@ const (
 func TagNKSMachine(ctx *context.MachineContext, vm *object.VirtualMachine) error {
 
 	tagManager := tags.NewManager(ctx.RestSession.Client)
-	clusterID, workspaceID, isServiceCluster := ctx.GetNKSClusterInfo()
+	clusterID, workspaceID, _, isServiceCluster := ctx.GetNKSClusterInfo()
 
 	ctx.Logger.V(4).Info("tagging VM with cluster information")
 	if err := tagWithClusterInfo(ctx, tagManager, vm.Reference(), workspaceID, clusterID, ctx.Cluster.Name); err != nil {
@@ -44,7 +44,7 @@ func TagNKSMachine(ctx *context.MachineContext, vm *object.VirtualMachine) error
 func CleanupNKSTags(ctx *context.MachineContext) error {
 
 	tagManager := tags.NewManager(ctx.RestSession.Client)
-	clusterID, workspaceID, isServiceCluster := ctx.GetNKSClusterInfo()
+	clusterID, workspaceID, _, isServiceCluster := ctx.GetNKSClusterInfo()
 
 	ctx.Logger.V(4).Info("cleaning up cluster information tag and category", "cluster", ctx.Cluster.Name)
 	if err := deleteClusterInfoTagAndCategory(ctx, tagManager, workspaceID, clusterID, ctx.Cluster.Name); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a NKS username to the **Note** section in vCenter to have a better overview who owns which cluster

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
f.x
<img width="720" alt="Screenshot 2019-11-18 at 14 45 52" src="https://user-images.githubusercontent.com/15950720/69065778-2a191080-0a18-11ea-8d19-bcd95f05bb3b.png">

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._


```release-note
NONE
```