### PR TITLE
NKS-2863 append prefix length suffix to ip addresses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/cluster-api-provider-vsphere
 go 1.12
 
 require (
-	github.com/NetApp/nks-on-prem-ipam v0.1.6-0.20191222155442-ddaab3f29fca
+	github.com/NetApp/nks-on-prem-ipam v0.1.6
 	github.com/go-logr/logr v0.1.0
 	github.com/google/uuid v1.1.1
 	github.com/onsi/ginkgo v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/cluster-api-provider-vsphere
 go 1.12
 
 require (
-	github.com/NetApp/nks-on-prem-ipam v0.1.5
+	github.com/NetApp/nks-on-prem-ipam v0.1.6-0.20191222155442-ddaab3f29fca
 	github.com/go-logr/logr v0.1.0
 	github.com/google/uuid v1.1.1
 	github.com/onsi/ginkgo v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -17,10 +17,8 @@ github.com/Azure/go-autorest/logger v0.1.0 h1:ruG4BSDXONFRrZZJ2GUXDiUyVpayPmb1Gn
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
 github.com/Azure/go-autorest/tracing v0.5.0 h1:TRn4WjSnkcSy5AEG3pnbtFSwNtwzjr4VYyQflFE619k=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
-github.com/NetApp/nks-on-prem-ipam v0.1.5 h1:l6BlckNPq+4DrP2xyceM7g4EqUY558JuiuQreZfI2vo=
-github.com/NetApp/nks-on-prem-ipam v0.1.5/go.mod h1:ZfJJsukCxUTPVF4RnekFnVMz27x8SuU4YlD2jaqCKSU=
-github.com/NetApp/nks-on-prem-ipam v0.1.6-0.20191222155442-ddaab3f29fca h1:snqWomi+mKyo6a2IWk5Ecl0hCu8DnpvWYvDIM2bZ6x8=
-github.com/NetApp/nks-on-prem-ipam v0.1.6-0.20191222155442-ddaab3f29fca/go.mod h1:ZfJJsukCxUTPVF4RnekFnVMz27x8SuU4YlD2jaqCKSU=
+github.com/NetApp/nks-on-prem-ipam v0.1.6 h1:KgCrbSVRiZJMWl96wL72KzBrOed5lUwPE+meBjHsYeU=
+github.com/NetApp/nks-on-prem-ipam v0.1.6/go.mod h1:ZfJJsukCxUTPVF4RnekFnVMz27x8SuU4YlD2jaqCKSU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6 h1:uZuxRZCz65cG1o6K/xUqImNcYKtmk9ylqaH0itMSvzA=

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/Azure/go-autorest/tracing v0.5.0 h1:TRn4WjSnkcSy5AEG3pnbtFSwNtwzjr4VY
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/NetApp/nks-on-prem-ipam v0.1.5 h1:l6BlckNPq+4DrP2xyceM7g4EqUY558JuiuQreZfI2vo=
 github.com/NetApp/nks-on-prem-ipam v0.1.5/go.mod h1:ZfJJsukCxUTPVF4RnekFnVMz27x8SuU4YlD2jaqCKSU=
+github.com/NetApp/nks-on-prem-ipam v0.1.6-0.20191222155442-ddaab3f29fca h1:snqWomi+mKyo6a2IWk5Ecl0hCu8DnpvWYvDIM2bZ6x8=
+github.com/NetApp/nks-on-prem-ipam v0.1.6-0.20191222155442-ddaab3f29fca/go.mod h1:ZfJJsukCxUTPVF4RnekFnVMz27x8SuU4YlD2jaqCKSU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6 h1:uZuxRZCz65cG1o6K/xUqImNcYKtmk9ylqaH0itMSvzA=

--- a/pkg/cloud/vsphere/services/ipam/ipam.go
+++ b/pkg/cloud/vsphere/services/ipam/ipam.go
@@ -11,6 +11,7 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha2"
 	capvcontext "sigs.k8s.io/cluster-api-provider-vsphere/pkg/cloud/vsphere/context"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strconv"
 )
 
 const (
@@ -240,7 +241,8 @@ func assignReservationsToDevices(reservations []ipam.IPAddressReservation, devic
 	}
 	for i, device := range devices {
 		reservation := reservations[i]
-		device.IPAddrs = append(device.IPAddrs, reservation.Address)
+		prefixLengthSuffix := "/" + strconv.Itoa(reservation.NetworkConfig.PrefixLength)
+		device.IPAddrs = append(device.IPAddrs, reservation.Address+prefixLengthSuffix)
 		device.Nameservers = reservation.NetworkConfig.NameServers
 		device.Gateway4 = reservation.NetworkConfig.DefaultGateway
 		device.SearchDomains = reservation.NetworkConfig.DomainSearch


### PR DESCRIPTION
Add a prefix length suffix to the static IPs (/xx).

Note that there is no way to supply a netmask to the nodes via `NetworkDeviceSpec`, and CAPV's cloud-init configuration doesn't specify `netmask`. So we pass in the IP addresses in CIDR notation, specifying the prefix length.