### PR TITLE
NKS-3154 Remove finalizer if parent cluster is being deleted

### DIFF
--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -170,6 +170,7 @@ func (r clusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr er
 	}()
 
 	// Handle deleted clusters
+	// NetApp - The second check is from us
 	if !vsphereCluster.DeletionTimestamp.IsZero() || !cluster.DeletionTimestamp.IsZero() {
 		return r.reconcileDelete(clusterContext)
 	}

--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -170,7 +170,7 @@ func (r clusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr er
 	}()
 
 	// Handle deleted clusters
-	if !vsphereCluster.DeletionTimestamp.IsZero() {
+	if !vsphereCluster.DeletionTimestamp.IsZero() || !cluster.DeletionTimestamp.IsZero() {
 		return r.reconcileDelete(clusterContext)
 	}
 

--- a/pkg/services/govmomi/service.go
+++ b/pkg/services/govmomi/service.go
@@ -34,6 +34,11 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
 
+const (
+	// NetApp - Marks a VM as tagged so we don't have to re-tag (It's very slow)
+	taggedAnnotationKey = "nks.netapp.io/tagged"
+)
+
 // VMService provdes API to interact with the VMs using govmomi
 type VMService struct{}
 
@@ -356,6 +361,10 @@ func (vms *VMService) getNetworkStatus(ctx *virtualMachineContext) ([]infrav1.Ne
 
 // NetApp
 func (vms *VMService) reconcileTags(ctx *context.MachineContext) error {
+	if _, ok := ctx.VSphereMachine.Annotations[taggedAnnotationKey]; ok {
+		return nil
+	}
+
 	vmRef, err := findVM(ctx)
 	if err != nil {
 		return err
@@ -364,6 +373,9 @@ func (vms *VMService) reconcileTags(ctx *context.MachineContext) error {
 	if err != nil {
 		return err
 	}
+
+	ctx.VSphereMachine.Annotations[taggedAnnotationKey] = "true"
+
 	return nil
 }
 


### PR DESCRIPTION
The deletion timestamp tends to be slow to arrive for the vspherecluster, and when it does the event doesn't always come in.

With this change we remove the finalizer if the parent cluster (CAPI) is being deleted, which will cause the vsphere cluster to disappear immediately.