### PR TITLE
Make tagging operations async

### DIFF
--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -212,7 +212,7 @@ func (r clusterReconciler) reconcileNormal(ctx *context.ClusterContext) (reconci
 		if err == infrautilv1.ErrNoMachineIPAddr {
 			ctx.Logger.Info("Waiting on an API endpoint")
 			return reconcile.Result{
-				RequeueAfter: 30 * time.Second,
+				RequeueAfter: 10 * time.Second,
 			}, nil
 		}
 		return reconcile.Result{}, errors.Wrapf(err,

--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -211,7 +211,9 @@ func (r clusterReconciler) reconcileNormal(ctx *context.ClusterContext) (reconci
 	if err := r.reconcileAPIEndpoints(ctx); err != nil {
 		if err == infrautilv1.ErrNoMachineIPAddr {
 			ctx.Logger.Info("Waiting on an API endpoint")
-			return reconcile.Result{}, nil
+			return reconcile.Result{
+				RequeueAfter: 30 * time.Second,
+			}, nil
 		}
 		return reconcile.Result{}, errors.Wrapf(err,
 			"failed to reconcile API endpoints for VSphereCluster %s/%s",

--- a/go.sum
+++ b/go.sum
@@ -329,6 +329,7 @@ k8s.io/apiextensions-apiserver v0.0.0-20190918201827-3de75813f604 h1:Kl/sh+wWzYK
 k8s.io/apiextensions-apiserver v0.0.0-20190918201827-3de75813f604/go.mod h1:7H8sjDlWQu89yWB3FhZfsLyRCRLuoXoCoY5qtwW1q6I=
 k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d h1:7Kns6qqhMAQWvGkxYOLSLRZ5hJO0/5pcE5lPGP2fxUw=
 k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d/go.mod h1:3jediapYqJ2w1BFw7lAZPCx7scubsTfosqHkhXCWJKw=
+k8s.io/apimachinery v0.17.2 h1:hwDQQFbdRlpnnsR64Asdi55GyCaIP/3WQpMmbNBeWr4=
 k8s.io/apiserver v0.0.0-20190918200908-1e17798da8c1/go.mod h1:4FuDU+iKPjdsdQSN3GsEKZLB/feQsj1y9dhhBDVV2Ns=
 k8s.io/client-go v0.0.0-20190918200256-06eb1244587a h1:huOvPq1vO7dkuw9rZPYsLGpFmyGvy6L8q6mDItgkdQ4=
 k8s.io/client-go v0.0.0-20190918200256-06eb1244587a/go.mod h1:3YAcTbI2ArBRmhHns5vlHRX8YQqvkVYpz+U/N5i1mVU=

--- a/pkg/services/govmomi/service.go
+++ b/pkg/services/govmomi/service.go
@@ -107,10 +107,12 @@ func (vms *VMService) ReconcileVM(ctx *context.MachineContext) (vm infrav1.Virtu
 	}
 
 	// NetApp
-	if err := vms.reconcileTags(ctx); err != nil {
-		// Just log the error
-		ctx.Logger.Error(err, "error reconciling tags")
-	}
+	go func() {
+		if err := vms.reconcileTags(ctx); err != nil {
+			// Just log the error
+			ctx.Logger.Error(err, "error reconciling tags")
+		}
+	}()
 
 	vm.State = infrav1.VirtualMachineStateReady
 	return vm, nil
@@ -145,10 +147,12 @@ func (vms *VMService) DestroyVM(ctx *context.MachineContext) (infrav1.VirtualMac
 			vm.State = infrav1.VirtualMachineStateNotFound
 
 			// NetApp
-			if err := vms.deleteTags(ctx); err != nil {
-				// Just log the error
-				ctx.Logger.Error(err, "error deleting tags")
-			}
+			go func() {
+				if err := vms.deleteTags(ctx); err != nil {
+					// Just log the error
+					ctx.Logger.Error(err, "error deleting tags")
+				}
+			}()
 
 			return vm, nil
 		}

--- a/pkg/services/govmomi/service.go
+++ b/pkg/services/govmomi/service.go
@@ -107,12 +107,7 @@ func (vms *VMService) ReconcileVM(ctx *context.MachineContext) (vm infrav1.Virtu
 	}
 
 	// NetApp
-	go func() {
-		if err := vms.reconcileTags(ctx); err != nil {
-			// Just log the error
-			ctx.Logger.Error(err, "error reconciling tags")
-		}
-	}()
+	vms.reconcileTags(ctx)
 
 	vm.State = infrav1.VirtualMachineStateReady
 	return vm, nil
@@ -146,13 +141,7 @@ func (vms *VMService) DestroyVM(ctx *context.MachineContext) (infrav1.VirtualMac
 		if isNotFound(err) {
 			vm.State = infrav1.VirtualMachineStateNotFound
 
-			// NetApp
-			go func() {
-				if err := vms.deleteTags(ctx); err != nil {
-					// Just log the error
-					ctx.Logger.Error(err, "error deleting tags")
-				}
-			}()
+			vms.deleteTags(ctx)
 
 			return vm, nil
 		}
@@ -364,30 +353,37 @@ func (vms *VMService) getNetworkStatus(ctx *virtualMachineContext) ([]infrav1.Ne
 }
 
 // NetApp
-func (vms *VMService) reconcileTags(ctx *context.MachineContext) error {
+func (vms *VMService) reconcileTags(ctx *context.MachineContext) {
 	if _, ok := ctx.VSphereMachine.Annotations[taggedAnnotationKey]; ok {
-		return nil
+		return
 	}
-
-	vmRef, err := findVM(ctx)
-	if err != nil {
-		return err
-	}
-	err = tags.TagNKSMachine(ctx, vmRef)
-	if err != nil {
-		return err
-	}
-
 	ctx.VSphereMachine.Annotations[taggedAnnotationKey] = "true"
 
-	return nil
+	go func() {
+		vmRef, err := findVM(ctx)
+		if err != nil {
+			if err != nil {
+				// Just log the error
+				ctx.Logger.Error(err, "error reconciling tags")
+			}
+		}
+		err = tags.TagNKSMachine(ctx, vmRef)
+		if err != nil {
+			if err != nil {
+				// Just log the error
+				ctx.Logger.Error(err, "error reconciling tags")
+			}
+		}
+	}()
 }
 
 // NetApp
-func (vms *VMService) deleteTags(ctx *context.MachineContext) error {
-	err := tags.CleanupNKSTags(ctx)
-	if err != nil {
-		return err
-	}
-	return nil
+func (vms *VMService) deleteTags(ctx *context.MachineContext) {
+	go func() {
+		err := tags.CleanupNKSTags(ctx)
+		if err != nil {
+			// Just log the error
+			ctx.Logger.Error(err, "error reconciling tags")
+		}
+	}()
 }


### PR DESCRIPTION
This makes reconcile much faster, since tagging can take 10-20 seconds and it blocks all other events while being performed