### PR TITLE
Delete vspheremachine if CAPI machine is being deleted

### DIFF
--- a/controllers/vspheremachine_controller.go
+++ b/controllers/vspheremachine_controller.go
@@ -274,7 +274,7 @@ func (r machineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr er
 	}()
 
 	// Handle deleted machines
-	if !vsphereMachine.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !vsphereMachine.ObjectMeta.DeletionTimestamp.IsZero() || !machine.ObjectMeta.DeletionTimestamp.IsZero() {
 		return r.reconcileDelete(machineContext)
 	}
 

--- a/go.sum
+++ b/go.sum
@@ -330,6 +330,7 @@ k8s.io/apiextensions-apiserver v0.0.0-20190918201827-3de75813f604/go.mod h1:7H8s
 k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d h1:7Kns6qqhMAQWvGkxYOLSLRZ5hJO0/5pcE5lPGP2fxUw=
 k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d/go.mod h1:3jediapYqJ2w1BFw7lAZPCx7scubsTfosqHkhXCWJKw=
 k8s.io/apimachinery v0.17.2 h1:hwDQQFbdRlpnnsR64Asdi55GyCaIP/3WQpMmbNBeWr4=
+k8s.io/apimachinery v0.17.3 h1:f+uZV6rm4/tHE7xXgLyToprg6xWairaClGVkm2t8omg=
 k8s.io/apiserver v0.0.0-20190918200908-1e17798da8c1/go.mod h1:4FuDU+iKPjdsdQSN3GsEKZLB/feQsj1y9dhhBDVV2Ns=
 k8s.io/client-go v0.0.0-20190918200256-06eb1244587a h1:huOvPq1vO7dkuw9rZPYsLGpFmyGvy6L8q6mDItgkdQ4=
 k8s.io/client-go v0.0.0-20190918200256-06eb1244587a/go.mod h1:3YAcTbI2ArBRmhHns5vlHRX8YQqvkVYpz+U/N5i1mVU=


### PR DESCRIPTION
Experimenting with this a bit. Delete can be slow if there are 12+ clusters being deleted at the same time. The reason is that CAPI takes a while to put a delete timestamp on the vSpheremachines.

We're doing this with vsphereclusters and it improved delete times.